### PR TITLE
update: Refactor for upgraded PMD

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,9 +23,12 @@ apidocs/
 **/.settings/
 **/.pmd
 **/.ruleset
+**/.pmdruleset.xml
 
 #
 # General
 #
 **/.*.swp
+**/*.old
+**/*.old?
 

--- a/config/pmd-ruleset.xml
+++ b/config/pmd-ruleset.xml
@@ -1,24 +1,24 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ruleset xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         name="pmd-eclipse"
+         name="M2Eclipse PMD RuleSet"
          xsi:schemaLocation="http://pmd.sourceforge.net/ruleset/2.0.0 https://pmd.sourceforge.io/ruleset_2_0_0.xsd">
-   <description>PMD Plugin preferences rule set</description>
+   <description>M2Eclipse PMD RuleSet</description>
    <rule ref="category/java/bestpractices.xml/AbstractClassWithoutAbstractMethod"/>
    <rule ref="category/java/bestpractices.xml/AccessorClassGeneration"/>
    <rule ref="category/java/bestpractices.xml/AccessorMethodGeneration"/>
    <rule ref="category/java/bestpractices.xml/ArrayIsStoredDirectly"/>
    <rule ref="category/java/bestpractices.xml/AvoidMessageDigestField"/>
    <rule ref="category/java/bestpractices.xml/AvoidPrintStackTrace"/>
+   <rule ref="category/java/bestpractices.xml/AvoidReassigningCatchVariables"/>
    <rule ref="category/java/bestpractices.xml/AvoidReassigningLoopVariables"/>
-   <!--
    <rule ref="category/java/bestpractices.xml/AvoidReassigningParameters"/>
-   -->
    <rule ref="category/java/bestpractices.xml/AvoidStringBufferField"/>
    <rule ref="category/java/bestpractices.xml/AvoidUsingHardCodedIP"/>
    <rule ref="category/java/bestpractices.xml/CheckResultSet"/>
    <rule ref="category/java/bestpractices.xml/ConstantsInInterface"/>
    <rule ref="category/java/bestpractices.xml/DefaultLabelNotLastInSwitchStmt"/>
+   <rule ref="category/jsp/bestpractices.xml/DontNestJsfInJstlIteration"/>
    <rule ref="category/java/bestpractices.xml/DoubleBraceInitialization"/>
    <rule ref="category/java/bestpractices.xml/ForLoopCanBeForeach"/>
    <rule ref="category/java/bestpractices.xml/ForLoopVariableCount"/>
@@ -28,25 +28,23 @@
    <rule ref="category/java/bestpractices.xml/JUnit4TestShouldUseBeforeAnnotation"/>
    <rule ref="category/java/bestpractices.xml/JUnit4TestShouldUseTestAnnotation"/>
    <rule ref="category/java/bestpractices.xml/JUnitAssertionsShouldIncludeMessage"/>
-
-   <!-- disable
-   <rule ref="category/java/bestpractices.xml/JUnitTestContainsTooManyAsserts"/>
-   -->
-
    <rule ref="category/java/bestpractices.xml/JUnitTestsShouldIncludeAssert"/>
    <rule ref="category/java/bestpractices.xml/JUnitUseExpected"/>
+   <rule ref="category/java/bestpractices.xml/LiteralsFirstInComparisons"/>
    <rule ref="category/java/bestpractices.xml/LooseCoupling"/>
    <rule ref="category/java/bestpractices.xml/MethodReturnsInternalArray"/>
    <rule ref="category/java/bestpractices.xml/MissingOverride"/>
+   <rule ref="category/jsp/bestpractices.xml/NoClassAttribute"/>
+   <rule ref="category/jsp/bestpractices.xml/NoHtmlComments"/>
+   <rule ref="category/jsp/bestpractices.xml/NoJspForward"/>
    <rule ref="category/java/bestpractices.xml/OneDeclarationPerLine"/>
-   <rule ref="category/java/bestpractices.xml/PositionLiteralsFirstInCaseInsensitiveComparisons"/>
-   <rule ref="category/java/bestpractices.xml/PositionLiteralsFirstInComparisons"/>
    <rule ref="category/java/bestpractices.xml/PreserveStackTrace"/>
    <rule ref="category/java/bestpractices.xml/ReplaceEnumerationWithIterator"/>
    <rule ref="category/java/bestpractices.xml/ReplaceHashtableWithMap"/>
    <rule ref="category/java/bestpractices.xml/ReplaceVectorWithList"/>
    <rule ref="category/java/bestpractices.xml/SwitchStmtsShouldHaveDefault"/>
    <rule ref="category/java/bestpractices.xml/SystemPrintln"/>
+   <rule ref="category/java/bestpractices.xml/UnusedAssignment"/>
    <rule ref="category/java/bestpractices.xml/UnusedFormalParameter"/>
    <rule ref="category/java/bestpractices.xml/UnusedImports"/>
    <rule ref="category/java/bestpractices.xml/UnusedLocalVariable"/>
@@ -60,48 +58,38 @@
    <rule ref="category/java/bestpractices.xml/UseTryWithResources"/>
    <rule ref="category/java/bestpractices.xml/UseVarargs"/>
    <rule ref="category/java/bestpractices.xml/WhileLoopWithLiteralBoolean"/>
-   <!--
-   <rule ref="category/java/codestyle.xml/AbstractNaming"/>
-   <rule ref="category/java/codestyle.xml/AtLeastOneConstructor"/>
    <rule ref="category/java/codestyle.xml/AvoidDollarSigns"/>
-   <rule ref="category/java/codestyle.xml/AvoidFinalLocalVariable"/>
-   <rule ref="category/java/codestyle.xml/AvoidPrefixingMethodParameters"/>
    <rule ref="category/java/codestyle.xml/AvoidProtectedFieldInFinalClass"/>
    <rule ref="category/java/codestyle.xml/AvoidProtectedMethodInFinalClassNotExtending"/>
    <rule ref="category/java/codestyle.xml/AvoidUsingNativeCode"/>
    <rule ref="category/java/codestyle.xml/BooleanGetMethodName"/>
+<!--
    <rule ref="category/java/codestyle.xml/CallSuperInConstructor"/>
+-->
    <rule ref="category/java/codestyle.xml/ClassNamingConventions"/>
-   <rule ref="category/java/codestyle.xml/CommentDefaultAccessModifier"/>
    <rule ref="category/java/codestyle.xml/ConfusingTernary"/>
    <rule ref="category/java/codestyle.xml/ControlStatementBraces"/>
-   <rule ref="category/java/codestyle.xml/DefaultPackage"/>
    <rule ref="category/java/codestyle.xml/DontImportJavaLang"/>
    <rule ref="category/java/codestyle.xml/DuplicateImports"/>
+   <rule ref="category/jsp/codestyle.xml/DuplicateJspImports"/>
    <rule ref="category/java/codestyle.xml/EmptyMethodInAbstractClassShouldBeAbstract"/>
    <rule ref="category/java/codestyle.xml/ExtendsObject"/>
    <rule ref="category/java/codestyle.xml/FieldDeclarationsShouldBeAtStartOfClass"/>
    <rule ref="category/java/codestyle.xml/FieldNamingConventions"/>
    <rule ref="category/java/codestyle.xml/ForLoopShouldBeWhileLoop"/>
-   <rule ref="category/java/codestyle.xml/ForLoopsMustUseBraces"/>
    <rule ref="category/java/codestyle.xml/FormalParameterNamingConventions"/>
    <rule ref="category/java/codestyle.xml/GenericsNaming"/>
    <rule ref="category/java/codestyle.xml/IdenticalCatchBranches"/>
-   <rule ref="category/java/codestyle.xml/IfElseStmtsMustUseBraces"/>
-   <rule ref="category/java/codestyle.xml/IfStmtsMustUseBraces"/>
    <rule ref="category/java/codestyle.xml/LinguisticNaming"/>
    <rule ref="category/java/codestyle.xml/LocalHomeNamingConvention"/>
    <rule ref="category/java/codestyle.xml/LocalInterfaceSessionNamingConvention"/>
-   <rule ref="category/java/codestyle.xml/LocalVariableCouldBeFinal"/>
    <rule ref="category/java/codestyle.xml/LocalVariableNamingConventions"/>
-   <rule ref="category/java/codestyle.xml/LongVariable"/>
    <rule ref="category/java/codestyle.xml/MDBAndSessionBeanNamingConvention"/>
-   <rule ref="category/java/codestyle.xml/MethodArgumentCouldBeFinal"/>
    <rule ref="category/java/codestyle.xml/MethodNamingConventions"/>
-   <rule ref="category/java/codestyle.xml/MIsLeadingVariableName"/>
    <rule ref="category/java/codestyle.xml/NoPackage"/>
-   <rule ref="category/java/codestyle.xml/UseUnderscoresInNumericLiterals"/>
+<!--
    <rule ref="category/java/codestyle.xml/OnlyOneReturn"/>
+-->
    <rule ref="category/java/codestyle.xml/PackageCase"/>
    <rule ref="category/java/codestyle.xml/PrematureDeclaration"/>
    <rule ref="category/java/codestyle.xml/RemoteInterfaceNamingConvention"/>
@@ -109,9 +97,8 @@
    <rule ref="category/java/codestyle.xml/ShortClassName"/>
    <rule ref="category/java/codestyle.xml/ShortMethodName"/>
    <rule ref="category/java/codestyle.xml/ShortVariable"/>
-   <rule ref="category/java/codestyle.xml/SuspiciousConstantFieldName"/>
-   <rule ref="category/java/codestyle.xml/TooManyStaticImports"/>
    <rule ref="category/java/codestyle.xml/UnnecessaryAnnotationValueElement"/>
+   <rule ref="category/java/codestyle.xml/UnnecessaryCast"/>
    <rule ref="category/java/codestyle.xml/UnnecessaryConstructor"/>
    <rule ref="category/java/codestyle.xml/UnnecessaryFullyQualifiedName"/>
    <rule ref="category/java/codestyle.xml/UnnecessaryLocalBeforeReturn"/>
@@ -121,9 +108,7 @@
    <rule ref="category/java/codestyle.xml/UselessParentheses"/>
    <rule ref="category/java/codestyle.xml/UselessQualifiedThis"/>
    <rule ref="category/java/codestyle.xml/UseShortArrayInitializer"/>
-   <rule ref="category/java/codestyle.xml/VariableNamingConventions"/>
-   <rule ref="category/java/codestyle.xml/WhileLoopsMustUseBraces"/>
-   -->
+   <rule ref="category/java/codestyle.xml/UseUnderscoresInNumericLiterals"/>
    <rule ref="category/java/design.xml/AbstractClassWithoutAnyMethod"/>
    <rule ref="category/java/design.xml/AvoidCatchingGenericException"/>
    <rule ref="category/java/design.xml/AvoidDeeplyNestedIfStmts"/>
@@ -139,64 +124,50 @@
    <rule ref="category/java/design.xml/DataClass"/>
    <rule ref="category/java/design.xml/DoNotExtendJavaLangError"/>
    <rule ref="category/java/design.xml/ExceptionAsFlowControl"/>
+<!--
    <rule ref="category/java/design.xml/ExcessiveClassLength"/>
+-->
    <rule ref="category/java/design.xml/ExcessiveImports"/>
+<!--
    <rule ref="category/java/design.xml/ExcessiveMethodLength"/>
+-->
    <rule ref="category/java/design.xml/ExcessiveParameterList"/>
    <rule ref="category/java/design.xml/ExcessivePublicCount"/>
    <rule ref="category/java/design.xml/FinalFieldCouldBeStatic"/>
+<!--
    <rule ref="category/java/design.xml/GodClass"/>
+-->
    <rule ref="category/java/design.xml/ImmutableField"/>
-
-   <!-- disable
+<!--
    <rule ref="category/java/design.xml/LawOfDemeter"/>
-   -->
+-->
    <rule ref="category/java/design.xml/LogicInversion"/>
-
-   <!-- deprecated
+<!--
    <rule ref="category/java/design.xml/LoosePackageCoupling"/>
-   -->
-
-   <!-- disable
-   <rule ref="category/java/design.xml/ModifiedCyclomaticComplexity"/>
-   -->
-
-   <!-- deprecated
-   <rule ref="category/java/design.xml/NcssConstructorCount"/>
+-->
    <rule ref="category/java/design.xml/NcssCount"/>
-   <rule ref="category/java/design.xml/NcssMethodCount"/>
-   <rule ref="category/java/design.xml/NcssTypeCount"/>
-   -->
+   <rule ref="category/jsp/design.xml/NoInlineScript"/>
+   <rule ref="category/jsp/design.xml/NoInlineStyleInformation"/>
+   <rule ref="category/jsp/design.xml/NoLongScripts"/>
+   <rule ref="category/jsp/design.xml/NoScriptlets"/>
    <rule ref="category/java/design.xml/NPathComplexity"/>
    <rule ref="category/java/design.xml/SignatureDeclareThrowsException"/>
-   <!-- disable
    <rule ref="category/java/design.xml/SimplifiedTernary"/>
-   -->
    <rule ref="category/java/design.xml/SimplifyBooleanAssertion"/>
    <rule ref="category/java/design.xml/SimplifyBooleanExpressions"/>
    <rule ref="category/java/design.xml/SimplifyBooleanReturns"/>
    <rule ref="category/java/design.xml/SimplifyConditional"/>
    <rule ref="category/java/design.xml/SingularField"/>
-
-   <!-- disable
-   <rule ref="category/java/design.xml/StdCyclomaticComplexity"/>
-   -->
-
    <rule ref="category/java/design.xml/SwitchDensity"/>
    <rule ref="category/java/design.xml/TooManyFields"/>
-
-   <!-- disable
+<!--
    <rule ref="category/java/design.xml/TooManyMethods"/>
-   -->
-
+-->
    <rule ref="category/java/design.xml/UselessOverridingMethod"/>
    <rule ref="category/java/design.xml/UseObjectForClearerAPI"/>
    <rule ref="category/java/design.xml/UseUtilityClass"/>
    <rule ref="category/java/documentation.xml/CommentContent"/>
    <rule ref="category/java/documentation.xml/CommentRequired"/>
-   <!-- disable
-   <rule ref="category/java/documentation.xml/CommentSize"/>
-   -->
    <rule ref="category/java/documentation.xml/UncommentedEmptyConstructor"/>
    <rule ref="category/java/documentation.xml/UncommentedEmptyMethodBody"/>
    <rule ref="category/java/errorprone.xml/AssignmentInOperand"/>
@@ -213,20 +184,14 @@
    <rule ref="category/java/errorprone.xml/AvoidFieldNameMatchingMethodName"/>
    <rule ref="category/java/errorprone.xml/AvoidFieldNameMatchingTypeName"/>
    <rule ref="category/java/errorprone.xml/AvoidInstanceofChecksInCatchClause"/>
-
-   <!-- disable
    <rule ref="category/java/errorprone.xml/AvoidLiteralsInIfCondition"/>
-   -->
-
    <rule ref="category/java/errorprone.xml/AvoidLosingExceptionInformation"/>
    <rule ref="category/java/errorprone.xml/AvoidMultipleUnaryOperators"/>
    <rule ref="category/java/errorprone.xml/AvoidUsingOctalValues"/>
    <rule ref="category/java/errorprone.xml/BadComparison"/>
-
-   <!-- way too many false positives
+<!--
    <rule ref="category/java/errorprone.xml/BeanMembersShouldSerialize"/>
-   -->
-
+-->
    <rule ref="category/java/errorprone.xml/BrokenNullCheck"/>
    <rule ref="category/java/errorprone.xml/CallSuperFirst"/>
    <rule ref="category/java/errorprone.xml/CallSuperLast"/>
@@ -239,7 +204,6 @@
    <rule ref="category/java/errorprone.xml/CloseResource"/>
    <rule ref="category/java/errorprone.xml/CompareObjectsWithEquals"/>
    <rule ref="category/java/errorprone.xml/ConstructorCallsOverridableMethod"/>
-   <rule ref="category/java/errorprone.xml/DataflowAnomalyAnalysis"/>
    <rule ref="category/java/errorprone.xml/DetachedTestCase"/>
    <rule ref="category/java/errorprone.xml/DoNotCallGarbageCollectionExplicitly"/>
    <rule ref="category/java/errorprone.xml/DoNotCallSystemExit"/>
@@ -267,15 +231,14 @@
    <rule ref="category/java/errorprone.xml/IdempotentOperations"/>
    <rule ref="category/java/errorprone.xml/ImportFromSamePackage"/>
    <rule ref="category/java/errorprone.xml/InstantiationToGetClass"/>
+<!-- error when running from CLI
+   <rule ref="category/pom/errorprone.xml/InvalidDependencyTypes"/>
+-->
    <rule ref="category/java/errorprone.xml/InvalidLogMessageFormat"/>
+   <rule ref="category/jsp/errorprone.xml/JspEncoding"/>
    <rule ref="category/java/errorprone.xml/JumbledIncrementer"/>
    <rule ref="category/java/errorprone.xml/JUnitSpelling"/>
    <rule ref="category/java/errorprone.xml/JUnitStaticSuite"/>
-
-   <!-- deprecated
-   <rule ref="category/java/errorprone.xml/LoggerIsNotStaticFinal"/>
-   -->
-
    <rule ref="category/java/errorprone.xml/MethodWithSameNameAsEnclosingClass"/>
    <rule ref="category/java/errorprone.xml/MisplacedNullCheck"/>
    <rule ref="category/java/errorprone.xml/MissingBreakInSwitch"/>
@@ -286,6 +249,9 @@
    <rule ref="category/java/errorprone.xml/NonStaticInitializer"/>
    <rule ref="category/java/errorprone.xml/NullAssignment"/>
    <rule ref="category/java/errorprone.xml/OverrideBothEqualsAndHashcode"/>
+<!-- error when running from CLI
+   <rule ref="category/pom/errorprone.xml/ProjectVersionAsDependencyVersion"/>
+-->
    <rule ref="category/java/errorprone.xml/ProperCloneImplementation"/>
    <rule ref="category/java/errorprone.xml/ProperLogger"/>
    <rule ref="category/java/errorprone.xml/ReturnEmptyArrayRatherThanNull"/>
@@ -298,9 +264,7 @@
    <rule ref="category/java/errorprone.xml/SuspiciousEqualsMethodName"/>
    <rule ref="category/java/errorprone.xml/SuspiciousHashcodeMethodName"/>
    <rule ref="category/java/errorprone.xml/SuspiciousOctalEscape"/>
-   <!-- test cases are inherited from the parent
    <rule ref="category/java/errorprone.xml/TestClassWithoutTestCases"/>
-   -->
    <rule ref="category/java/errorprone.xml/UnconditionalIfStatement"/>
    <rule ref="category/java/errorprone.xml/UnnecessaryBooleanAssertion"/>
    <rule ref="category/java/errorprone.xml/UnnecessaryCaseChange"/>
@@ -311,10 +275,6 @@
    <rule ref="category/java/errorprone.xml/UselessOperationOnImmutable"/>
    <rule ref="category/java/errorprone.xml/UseLocaleWithCaseConversions"/>
    <rule ref="category/java/errorprone.xml/UseProperClassLoader"/>
-   <!-- error running from Maven
-   <rule ref="category/pom/errorprone.xml/InvalidDependencyTypes"/>
-   <rule ref="category/pom/errorprone.xml/ProjectVersionAsDependencyVersion"/>
-   -->
    <rule ref="category/java/multithreading.xml/AvoidSynchronizedAtMethodLevel"/>
    <rule ref="category/java/multithreading.xml/AvoidThreadGroup"/>
    <rule ref="category/java/multithreading.xml/AvoidUsingVolatile"/>
@@ -322,15 +282,15 @@
    <rule ref="category/java/multithreading.xml/DontCallThreadRun"/>
    <rule ref="category/java/multithreading.xml/DoubleCheckedLocking"/>
    <rule ref="category/java/multithreading.xml/NonThreadSafeSingleton"/>
-<!-- deprecated
-   <rule ref="category/java/multithreading.xml/UnsynchronizedStaticDateFormatter"/>
--->
    <rule ref="category/java/multithreading.xml/UnsynchronizedStaticFormatter"/>
+<!--
    <rule ref="category/java/multithreading.xml/UseConcurrentHashMap"/>
+-->
    <rule ref="category/java/multithreading.xml/UseNotifyAllInsteadOfNotify"/>
    <rule ref="category/java/performance.xml/AddEmptyString"/>
    <rule ref="category/java/performance.xml/AppendCharacterWithChar"/>
    <rule ref="category/java/performance.xml/AvoidArrayLoops"/>
+   <rule ref="category/java/performance.xml/AvoidCalendarDateCreation"/>
    <rule ref="category/java/performance.xml/AvoidFileStream"/>
    <rule ref="category/java/performance.xml/AvoidInstantiatingObjectsInLoops"/>
    <rule ref="category/java/performance.xml/AvoidUsingShortType"/>
@@ -346,8 +306,8 @@
    <rule ref="category/java/performance.xml/LongInstantiation"/>
    <rule ref="category/java/performance.xml/OptimizableToArrayCall"/>
    <rule ref="category/java/performance.xml/RedundantFieldInitializer"/>
-   <rule ref="category/java/performance.xml/SimplifyStartsWith"/>
    <rule ref="category/java/performance.xml/ShortInstantiation"/>
+   <rule ref="category/java/performance.xml/SimplifyStartsWith"/>
    <rule ref="category/java/performance.xml/StringInstantiation"/>
    <rule ref="category/java/performance.xml/StringToString"/>
    <rule ref="category/java/performance.xml/TooFewBranchesForASwitchStatement"/>
@@ -355,10 +315,12 @@
    <rule ref="category/java/performance.xml/UseArrayListInsteadOfVector"/>
    <rule ref="category/java/performance.xml/UseArraysAsList"/>
    <rule ref="category/java/performance.xml/UseIndexOfChar"/>
+   <rule ref="category/java/performance.xml/UseIOStreamsWithApacheCommonsFileItem"/>
    <rule ref="category/java/performance.xml/UselessStringValueOf"/>
    <rule ref="category/java/performance.xml/UseStringBufferForStringAppends"/>
    <rule ref="category/java/performance.xml/UseStringBufferLength"/>
    <rule ref="category/java/security.xml/HardCodedCryptoKey"/>
+   <rule ref="category/jsp/security.xml/IframeMissingSrcAttribute"/>
    <rule ref="category/java/security.xml/InsecureCryptoIv"/>
+   <rule ref="category/jsp/security.xml/NoUnsanitizedJSPExpression"/>
 </ruleset>
-

--- a/module/jsonurl-core/src/main/java/org/jsonurl/BigMath.java
+++ b/module/jsonurl-core/src/main/java/org/jsonurl/BigMath.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 David MacCormack
+ * Copyright 2019-2020 David MacCormack
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy
@@ -25,9 +25,9 @@ import java.math.MathContext;
 public class BigMath implements BigMathProvider {
 
     /**
-     * MathContext for new BigDecimal instances. 
+     * MathContext for new BigDecimal instances.
      */
-    private final MathContext mc;
+    private final MathContext mathContext;
 
     /**
      * Positive BigInteger boundary.
@@ -46,18 +46,18 @@ public class BigMath implements BigMathProvider {
 
     /**
      * Create a new BigMath.
-     * @param mc a valid MathContext or null
+     * @param mctxt a valid MathContext or null
      * @param bigIntegerBoundaryNeg negative value boundary
      * @param bigIntegerBoundaryPos positive value boundary
      * @param bigIntegerOverflow action on boundary overflow
      */
     public BigMath(
-        MathContext mc,
+        MathContext mctxt,
         String bigIntegerBoundaryNeg,
         String bigIntegerBoundaryPos,
         BigIntegerOverflow bigIntegerOverflow) {
 
-        this.mc = mc;
+        this.mathContext = mctxt;
         this.bigIntegerBoundaryNeg = bigIntegerBoundaryNeg;
         this.bigIntegerBoundaryPos = bigIntegerBoundaryPos;
         this.bigIntegerOverflow = bigIntegerOverflow;
@@ -65,7 +65,7 @@ public class BigMath implements BigMathProvider {
 
     @Override
     public MathContext getMathContext() {
-        return mc;
+        return mathContext;
     }
 
     @Override

--- a/module/jsonurl-core/src/main/java/org/jsonurl/BigMathProvider.java
+++ b/module/jsonurl-core/src/main/java/org/jsonurl/BigMathProvider.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright 2019-2020 David MacCormack
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package org.jsonurl;
 
 import java.math.MathContext;
@@ -10,62 +27,58 @@ import java.math.MathContext;
  * @since 2020-08-02
  */
 public interface BigMathProvider {
-    
-
     /**
      * 32-bit integer negative boundary.
      */
-    public static final String BIG_INTEGER32_BOUNDARY_NEG =
+    String BIG_INTEGER32_BOUNDARY_NEG =
         String.valueOf(Integer.MIN_VALUE).substring(1);
 
     /**
      * 32-bit integer positive boundary.
      */
-    public static final String BIG_INTEGER32_BOUNDARY_POS =
+    String BIG_INTEGER32_BOUNDARY_POS =
         String.valueOf(Integer.MAX_VALUE);
     
     /**
      * 64-bit integer negative boundary.
      */
-    public static final String BIG_INTEGER64_BOUNDARY_NEG =
+    String BIG_INTEGER64_BOUNDARY_NEG =
         String.valueOf(Long.MIN_VALUE).substring(1);
 
     /**
      * 64-bit integer positive boundary.
      */
-    public static final String BIG_INTEGER64_BOUNDARY_POS =
+    String BIG_INTEGER64_BOUNDARY_POS =
         String.valueOf(Long.MAX_VALUE);
 
     /**
      * 128-bit integer negative boundary.
      */
-    public static final String BIG_INTEGER128_BOUNDARY_NEG =
+    String BIG_INTEGER128_BOUNDARY_NEG =
         "170141183460469231731687303715884105728";
 
     /**
      * 128-bit integer positive boundary.
      */
-    public static final String BIG_INTEGER128_BOUNDARY_POS =
+    String BIG_INTEGER128_BOUNDARY_POS =
         "170141183460469231731687303715884105727";
 
 
     /**
      * POSITIVE_INFINITY as an instance of Double.
      */
-    public final Double POSITIVE_INFINITY =
-        Double.valueOf(Double.POSITIVE_INFINITY);
+    Double POSITIVE_INFINITY = Double.valueOf(Double.POSITIVE_INFINITY);
     
     /**
      * NEGATIVE_INFINITY as an instance of Double.
      */
-    public final Double NEGATIVE_INFINITY =
-        Double.valueOf(Double.NEGATIVE_INFINITY);
+    Double NEGATIVE_INFINITY = Double.valueOf(Double.NEGATIVE_INFINITY);
     
     /**
      * Enumeration of BigInteger overflow operations.
      * When a value is too big (or too small) take one of these actions.
      */
-    public enum BigIntegerOverflow {
+    enum BigIntegerOverflow {
         /**
          * produce a Double instead.
          */
@@ -87,13 +100,13 @@ public interface BigMathProvider {
      * Get the MathContext from this provider.
      * @return a valid MathContext or null
      */
-    public MathContext getMathContext();
+    MathContext getMathContext();
 
     /**
      * Get the negative or positive BigInteger boundary.
      * @return a valid string or null
      */
-    public String getBigIntegerBoundary(boolean negative);
+    String getBigIntegerBoundary(boolean negative);
 
     /**
      * Determine what happens on overflow. If this method returns null then an
@@ -101,5 +114,5 @@ public interface BigMathProvider {
      *
      * @return a valid BigIntegerOverflow or null
      */
-    public BigIntegerOverflow getBigIntegerOverflow();
+    BigIntegerOverflow getBigIntegerOverflow();
 }

--- a/module/jsonurl-core/src/main/java/org/jsonurl/CharUtil.java
+++ b/module/jsonurl-core/src/main/java/org/jsonurl/CharUtil.java
@@ -1,7 +1,5 @@
-package org.jsonurl;
-
 /*
- * Copyright 2019 David MacCormack
+ * Copyright 2019-2020 David MacCormack
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy
@@ -16,6 +14,8 @@ package org.jsonurl;
  * specific language governing permissions and limitations
  * under the License.
  */
+
+package org.jsonurl;
 
 /**
  * Character metadata.
@@ -143,6 +143,11 @@ final class CharUtil {
     };
 
     /**
+     * number of array members.
+     */
+    static final int CHARBITS_LENGTH = CHARBITS.length;
+
+    /**
      * table for decoding URL-encoded strings.
      */
     private static final int[] HEXDECODE_TABLE = {
@@ -210,27 +215,23 @@ final class CharUtil {
         }
     }
 
-    static final boolean isDigit(char c) {
-        return c <= 127 && ((CHARBITS[c] & IS_DIGIT) != 0);
+    static boolean isDigit(char c) { // NOPMD - ShortVariable
+        return c <= 127 && (CHARBITS[c] & IS_DIGIT) != 0;
     }
 
-    static final int hexDecode(char c) {
+    static int hexDecode(char c) { // NOPMD - ShortVariable
         return c > 127 ? -1 : HEXDECODE_TABLE[c];
     }
 
-    static final int digits(CharSequence s, int pos, int stop) {
-        for (;;) {
-            if (pos == stop) {
-                return stop;
-            }
-
-            char c = s.charAt(pos);
+    static int digits(CharSequence text, int pos, int stop) {
+        for (int i = pos; i < stop; i++) {
+            char c = text.charAt(i); // NOPMD - ShortVariable
             if (c > 127 || (CHARBITS[c] & IS_DIGIT) == 0) {
-                return pos;
+                return i; // NOPMD - OnlyOneReturn
             }
-            
-            pos++;
         }
+        
+        return stop;
     }
 
     private CharUtil() {

--- a/module/jsonurl-core/src/main/java/org/jsonurl/JsonTextBuilder.java
+++ b/module/jsonurl-core/src/main/java/org/jsonurl/JsonTextBuilder.java
@@ -1,7 +1,5 @@
-package org.jsonurl;
-
 /*
- * Copyright 2019 David MacCormack
+ * Copyright 2019-2020 David MacCormack
  * 
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy
@@ -16,6 +14,8 @@ package org.jsonurl;
  * specific language governing permissions and limitations
  * under the License.
  */
+
+package org.jsonurl;
 
 import java.io.IOException;
 import java.math.BigDecimal;
@@ -38,76 +38,77 @@ public interface JsonTextBuilder<A,R> {
     /**
      * Begin an object.
      */
-    public JsonTextBuilder<A,R> beginObject() throws IOException;
+    JsonTextBuilder<A,R> beginObject() throws IOException;
 
     /**
      * End an object.
      */
-    public JsonTextBuilder<A,R> endObject() throws IOException;
+    JsonTextBuilder<A,R> endObject() throws IOException;
 
     /**
      * Begin an array.
      */
-    public JsonTextBuilder<A,R> beginArray() throws IOException;
+    JsonTextBuilder<A,R> beginArray() throws IOException;
 
     /**
      * End an array.
      */
-    public JsonTextBuilder<A,R> endArray() throws IOException;
+    JsonTextBuilder<A,R> endArray() throws IOException;
 
     /**
      * Separate two values.
      */
-    public JsonTextBuilder<A,R> valueSeparator() throws IOException;
+    JsonTextBuilder<A,R> valueSeparator() throws IOException;
 
     /**
      * Separate a name from its value.
      */
-    public JsonTextBuilder<A,R> nameSeparator() throws IOException;
+    JsonTextBuilder<A,R> nameSeparator() throws IOException;
 
     /**
      * Add a null value.
      */
-    public JsonTextBuilder<A,R> addNull() throws IOException;
+    JsonTextBuilder<A,R> addNull() throws IOException;
 
     /**
      * Add a long value.
      */
-    public JsonTextBuilder<A,R> add(long value) throws IOException;
+    JsonTextBuilder<A,R> add(long value) throws IOException;
 
     /**
      * Add a double value.
      */
-    public JsonTextBuilder<A,R> add(double value) throws IOException;
+    JsonTextBuilder<A,R> add(double value) throws IOException;
 
     /**
      * Add a BigDecimal value.
      */
-    public JsonTextBuilder<A,R> add(BigDecimal value) throws IOException;
+    JsonTextBuilder<A,R> add(BigDecimal value) throws IOException;
 
     /**
      * Add a BigInteger value.
      */
-    public JsonTextBuilder<A,R> add(BigInteger value) throws IOException;
+    JsonTextBuilder<A,R> add(BigInteger value) throws IOException;
 
     /**
      * Add a boolean value.
      */
-    public JsonTextBuilder<A,R> add(boolean value) throws IOException;
+    JsonTextBuilder<A,R> add(boolean value) throws IOException;
 
     /**
      * Add a boolean value.
      */
-    public JsonTextBuilder<A,R> add(char value) throws IOException;
+    JsonTextBuilder<A,R> add(char value) throws IOException;
 
     /**
      * Add a string value.
+     * @param text a valid CharSequence
      * @param start start index
      * @param end stop index
      * @param isKey true if this is an object key
      */
-    public JsonTextBuilder<A,R> add(
-            CharSequence s,
+    JsonTextBuilder<A,R> add(
+            CharSequence text,
             int start,
             int end,
             boolean isKey) throws IOException;
@@ -173,12 +174,12 @@ public interface JsonTextBuilder<A,R> {
      *
      * <p>This is simply a convenience for
      * {@link #add(CharSequence, int, int, boolean)
-     * add(s,0,s.length(),false)}.
-     * @param s the character sequence to add 
+     * add(text,0,text.length(),false)}.
+     * @param text the character sequence to add 
      * @see #add(CharSequence, int, int, boolean)
      */
-    default JsonTextBuilder<A,R> add(CharSequence s) throws IOException {
-        return add(s, 0, s.length(), false);
+    default JsonTextBuilder<A,R> add(CharSequence text) throws IOException {
+        return add(text, 0, text.length(), false);
     }
 
     /**
@@ -186,13 +187,13 @@ public interface JsonTextBuilder<A,R> {
      *
      * <p>This is simply a convenience for
      * {@link #add(CharSequence, int, int, boolean)
-     * add(s,0,s.length(),false)}.
-     * @param s the character sequence to add 
+     * add(text,0,text.length(),false)}.
+     * @param text the character sequence to add 
      * @param isKey true if this is an object key
      * @see #add(CharSequence, int, int, boolean)
      */
-    default JsonTextBuilder<A,R> add(CharSequence s, boolean isKey) throws IOException {
-        return add(s, 0, s.length(), isKey);
+    default JsonTextBuilder<A,R> add(CharSequence text, boolean isKey) throws IOException {
+        return add(text, 0, text.length(), isKey);
     }
 
     /**
@@ -200,17 +201,17 @@ public interface JsonTextBuilder<A,R> {
      *
      * <p>This is simply a convenience for
      * {@link #add(CharSequence, int, int, boolean)
-     * add(s,start,end,false)}.
-     * @param s the character sequence to add
+     * add(text,start,end,false)}.
+     * @param text the character sequence to add
      * @param start start index
      * @param end stop index
      * @see #add(CharSequence, int, int, boolean)
      */
     default JsonTextBuilder<A,R> add(
-            CharSequence s,
+            CharSequence text,
             int start,
             int end) throws IOException {
-        return add(s, start, end, false);
+        return add(text, start, end, false);
     }
 
     /**
@@ -218,12 +219,12 @@ public interface JsonTextBuilder<A,R> {
      *
      * <p>This is simply a convenience for
      * {@link #add(CharSequence, int, int, boolean)
-     * add(s,0,s.length(),true)}.
-     * @param s the character sequence to add 
+     * add(text,0,text.length(),true)}.
+     * @param text the character sequence to add 
      * @see #add(CharSequence, int, int, boolean)
      */
-    default JsonTextBuilder<A,R> addKey(CharSequence s) throws IOException {
-        return add(s, 0, s.length(), true);
+    default JsonTextBuilder<A,R> addKey(CharSequence text) throws IOException {
+        return add(text, 0, text.length(), true);
     }
 
     /**
@@ -231,15 +232,15 @@ public interface JsonTextBuilder<A,R> {
      *
      * <p>This is simply a convenience for
      * {@link #add(CharSequence, int, int, boolean)
-     * add(s,start,end,true)}.
-     * @param s the character sequence to add 
+     * add(text,start,end,true)}.
+     * @param text the character sequence to add 
      * @see #add(CharSequence, int, int, boolean)
      */
     default JsonTextBuilder<A,R> addKey(
-            CharSequence s,
+            CharSequence text,
             int start,
             int end) throws IOException {
-        return add(s, start, end, true);
+        return add(text, start, end, true);
     }
 
     /**
@@ -254,5 +255,5 @@ public interface JsonTextBuilder<A,R> {
      * Build the result.
      * @return a valid object
      */
-    public R build();
+    R build();
 }

--- a/module/jsonurl-core/src/main/java/org/jsonurl/JsonUrlStringBuilder.java
+++ b/module/jsonurl-core/src/main/java/org/jsonurl/JsonUrlStringBuilder.java
@@ -1,7 +1,5 @@
-package org.jsonurl;
-
 /*
- * Copyright 2019 David MacCormack
+ * Copyright 2019-2020 David MacCormack
  * 
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy
@@ -16,6 +14,8 @@ package org.jsonurl;
  * specific language governing permissions and limitations
  * under the License.
  */
+
+package org.jsonurl;
 
 /**
  * A JsonUrlTextAppender that appends JSON&#x2192;URL text to a StringBuilder.
@@ -55,8 +55,8 @@ public class JsonUrlStringBuilder extends
     /**
      * Create a new JsonUrlStringBuilder.
      */
-    public JsonUrlStringBuilder(StringBuilder sb) {
-        super(sb);
+    public JsonUrlStringBuilder(StringBuilder dest) {
+        super(dest);
     }
 
     @Override

--- a/module/jsonurl-core/src/main/java/org/jsonurl/JsonUrlTextAppender.java
+++ b/module/jsonurl-core/src/main/java/org/jsonurl/JsonUrlTextAppender.java
@@ -1,7 +1,5 @@
-package org.jsonurl;
-
 /*
- * Copyright 2019 David MacCormack
+ * Copyright 2019-2020 David MacCormack
  * 
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy
@@ -17,6 +15,8 @@ package org.jsonurl;
  * under the License.
  */
 
+package org.jsonurl;
+
 import java.io.IOException;
 import java.math.BigDecimal;
 import java.math.BigInteger;
@@ -30,8 +30,8 @@ import java.math.BigInteger;
  * @author David MacCormack
  * @since 2019-09-01
  */
-public abstract class JsonUrlTextAppender<A extends Appendable, R>
-        implements JsonTextBuilder<A, R>, Appendable { 
+public abstract class JsonUrlTextAppender<A extends Appendable, R> // NOPMD
+        implements JsonTextBuilder<A, R>, Appendable {
 
     /**
      * Destination, provided in constructor.
@@ -138,11 +138,11 @@ public abstract class JsonUrlTextAppender<A extends Appendable, R>
 
     @Override
     public JsonUrlTextAppender<A,R> add(
-            CharSequence s,
+            CharSequence text,
             int start,
             int end,
             boolean isKey) throws IOException {
-        JsonUrl.appendLiteral(out, s, start, end, isKey);
+        JsonUrl.appendLiteral(out, text, start, end, isKey);
         return this;
     }
     
@@ -162,8 +162,8 @@ public abstract class JsonUrlTextAppender<A extends Appendable, R>
     }
 
     @Override
-    public JsonUrlTextAppender<A,R> append(char c) throws IOException {
-        out.append(c);
+    public JsonUrlTextAppender<A,R> append(char value) throws IOException {
+        out.append(value);
         return this;
     }
 
@@ -183,7 +183,9 @@ public abstract class JsonUrlTextAppender<A extends Appendable, R>
      * 
      * @param wwwFormUrlEncoded true or false
      */
-    public JsonUrlTextAppender<A,R> setFormUrlEncoded(boolean wwwFormUrlEncoded) {
+    public JsonUrlTextAppender<A,R> setFormUrlEncoded(// NOPMD - LinguisticNaming
+            boolean wwwFormUrlEncoded) {
+
         this.wwwFormUrlEncoded = wwwFormUrlEncoded;
         return this;
     }
@@ -200,7 +202,8 @@ public abstract class JsonUrlTextAppender<A extends Appendable, R>
      * Set this to true to output an implied array or object.
      * @param implied true or false
      */
-    public JsonUrlTextAppender<A,R> setImplied(boolean implied) {
+    public JsonUrlTextAppender<A,R> setImplied(// NOPMD - LinguisticNaming
+            boolean implied) {
         this.implied = implied;
         return this;
     }

--- a/module/jsonurl-core/src/main/java/org/jsonurl/LimitException.java
+++ b/module/jsonurl-core/src/main/java/org/jsonurl/LimitException.java
@@ -1,7 +1,5 @@
-package org.jsonurl;
-
 /*
- * Copyright 2019 David MacCormack
+ * Copyright 2019-2020 David MacCormack
  * 
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy
@@ -17,10 +15,12 @@ package org.jsonurl;
  * under the License.
  */
 
+package org.jsonurl;
+
 /**
  * A exception that occurs when a limit is exceeded.
  */
-public class LimitException extends ParseException {
+public class LimitException extends ParseException { // NOPMD - not a bean
     
     /**
      * Enumeration of messages.
@@ -40,7 +40,7 @@ public class LimitException extends ParseException {
         
         private final String text;
 
-        private Message(String text) {
+        Message(String text) {
             this.text = text;
         }
 

--- a/module/jsonurl-core/src/main/java/org/jsonurl/NumberBuilder.java
+++ b/module/jsonurl-core/src/main/java/org/jsonurl/NumberBuilder.java
@@ -1,7 +1,5 @@
-package org.jsonurl;
-
 /*
- * Copyright 2019 David MacCormack
+ * Copyright 2019-2020 David MacCormack
  * 
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy
@@ -16,6 +14,8 @@ package org.jsonurl;
  * specific language governing permissions and limitations
  * under the License.
  */
+
+package org.jsonurl;
 
 import static org.jsonurl.BigMathProvider.NEGATIVE_INFINITY;
 import static org.jsonurl.BigMathProvider.POSITIVE_INFINITY;
@@ -109,10 +109,23 @@ public class NumberBuilder implements NumberText { // NOPMD
      */
     private static final int LONG_MAX_DIGITS =
         LONG_BOUNDARY_POS.length();
+
+    /**
+     * minus/dash.
+     */
+    private static final char MINUS = '-';
+
+    /**
+     * minus/dash.
+     */
+    private static final char PLUS = '+';
     
     /**
      * Lookup table for exponent values.
      */
+    @SuppressWarnings({
+        "PMD.UseUnderscoresInNumericLiterals",
+        "PMD.ShortVariable"})
     private static final long[] E = {
         1,                      // 0
         10,                     // 1
@@ -208,12 +221,12 @@ public class NumberBuilder implements NumberText { // NOPMD
 
     /**
      * Create a new NumberBuilder with the given text.
-     * @param s text
+     * @param text text
      * @param start start index
      * @param stop stop index
      */
-    public NumberBuilder(CharSequence s, int start, int stop) {
-        parse(s, start, stop);
+    public NumberBuilder(CharSequence text, int start, int stop) {
+        parse(text, start, stop);
     }
 
     /**
@@ -223,8 +236,8 @@ public class NumberBuilder implements NumberText { // NOPMD
      * #NumberBuilder(CharSequence, int, int)
      * NumberBuilder(s, 0, s.length())}.
      */
-    public NumberBuilder(CharSequence s) {
-        parse(s, 0, s.length());
+    public NumberBuilder(CharSequence text) {
+        parse(text, 0, text.length());
     }
 
     /**
@@ -254,23 +267,25 @@ public class NumberBuilder implements NumberText { // NOPMD
             fractIndexStart = fractIndexStop =
             expIndexStart = expIndexStop = -1;
     }
-    
-    private static final boolean hasFract(
+
+    private static boolean hasFract(
+            CharSequence text,
             int start,
-            int stop,
-            CharSequence s) {
+            int stop) {
 
-        if (start == stop || s.charAt(start) != '.') {
+        int i = start; // NOPMD
+
+        if (stop <= i || text.charAt(i) != '.') {
             return false;
         }
 
-        start++;
+        i++;
 
-        if (start == stop) { 
+        if (i == stop) { 
             return false;
         }
 
-        return isDigit(s.charAt(start));
+        return isDigit(text.charAt(i));
     }
     
     @Override
@@ -281,22 +296,22 @@ public class NumberBuilder implements NumberText { // NOPMD
     /**
      * Calculate exponent string.
      */
-    // "PMD.CyclomaticComplexity" - but PMD compains about dup literals
-    @SuppressWarnings("PMD")
-    private static final NumberText.Exponent getExponentType(
-            CharSequence s,
+    private static NumberText.Exponent getExponentType(//NOPMD
+            CharSequence text,
             int start,
             int stop) {
 
-        if (start == stop) {
+        if (stop <= start) {
             return NumberText.Exponent.NONE;
         }
 
-        switch (s.charAt(start)) {
+        int i = start; // NOPMD
+
+        switch (text.charAt(i)) {
         case 'e':
         case 'E':
-            start++;
-            if (start == stop) {
+            i++;
+            if (i == stop) {
                 return NumberText.Exponent.NONE;
             }
             break;
@@ -304,28 +319,28 @@ public class NumberBuilder implements NumberText { // NOPMD
             return NumberText.Exponent.NONE;
         }
 
-        NumberText.Exponent ret = null;
-        char c = s.charAt(start);
+        final NumberText.Exponent ret;
+        char c = text.charAt(i); //NOPMD
 
         switch (c) {
-        case '+':
-            start++;
-            if (start == stop) {
+        case PLUS:
+            i++;
+            if (i == stop) {
                 return NumberText.Exponent.NONE;
             }
-            c = s.charAt(start);
-            ret = NumberText.Exponent.POSITIVE_VALUE;
+            c = text.charAt(i);
+            ret = NumberText.Exponent.POSITIVE_VALUE; //NOPMD
             break;
-        case '-':
-            start++;
-            if (start == stop) {
+        case MINUS:
+            i++;
+            if (i == stop) {
                 return NumberText.Exponent.NONE;
             }
-            c = s.charAt(start);
-            ret = NumberText.Exponent.NEGATIVE_VALUE;
+            c = text.charAt(i);
+            ret = NumberText.Exponent.NEGATIVE_VALUE; //NOPMD
             break;
         default:
-            ret = NumberText.Exponent.JUST_VALUE;
+            ret = NumberText.Exponent.JUST_VALUE; //NOPMD
             break;
         }
         if (!isDigit(c)) {
@@ -343,25 +358,24 @@ public class NumberBuilder implements NumberText { // NOPMD
      * you can parse text without regard to how a number might be built later
      * via the {@link #build(boolean)} method.
      *
-     * @param s a valid CharSequence
+     * @param text a valid CharSequence
      * @param start an index
      * @param stop an index
      * @return true if the CharSequence was successfully parsed
      */
-    @SuppressWarnings("PMD")
-    public boolean parse(CharSequence s, int start, int stop) {
-        int pos = this.start = start;
+    public boolean parse(CharSequence text, int start, int stop) { //NOPMD
+        int pos = this.start = start; //NOPMD
 
-        char c = s.charAt(start);
+        char c = text.charAt(start); //NOPMD
 
-        if (c == '-') {
+        if (c == MINUS) {
             pos++;
 
             if (pos == stop) {
                 return false;
             }
 
-            c = s.charAt(pos);
+            c = text.charAt(pos);
         }
 
         switch (c) {
@@ -379,7 +393,7 @@ public class NumberBuilder implements NumberText { // NOPMD
         case '8':
         case '9':
             intIndexStart = pos;
-            pos = digits(s, pos + 1, stop);
+            pos = digits(text, pos + 1, stop);
             break;
         default:
             return false;
@@ -387,28 +401,28 @@ public class NumberBuilder implements NumberText { // NOPMD
 
         intIndexStop = pos;
 
-        if (hasFract(pos, stop, s)) {
+        if (hasFract(text, pos, stop)) {
             fractIndexStart = pos + 1;
-            fractIndexStop = pos = digits(s, pos + 1, stop);
+            fractIndexStop = pos = digits(text, pos + 1, stop);
         }
 
-        exponentType = getExponentType(s, pos, stop);
+        exponentType = getExponentType(text, pos, stop);
 
-        switch (exponentType) {
+        switch (exponentType) { // NOPMD - SwitchStmtsShouldHaveDefault
         case JUST_VALUE:
             expIndexStart = pos + 1;
-            pos = expIndexStop = digits(s, expIndexStart, stop);
+            pos = expIndexStop = digits(text, expIndexStart, stop);
             break;
         case NEGATIVE_VALUE:
         case POSITIVE_VALUE:
             expIndexStart = pos + 2;
-            pos = expIndexStop = digits(s, expIndexStart, stop);
+            pos = expIndexStop = digits(text, expIndexStart, stop);
             break;
         case NONE:
             break;
         }
 
-        this.text = s;
+        this.text = text;
         this.stop = stop;
         
         boolean isNumber = pos == stop;
@@ -426,8 +440,8 @@ public class NumberBuilder implements NumberText { // NOPMD
      * <p>Convenience for {@link #isNumber(CharSequence, int, int, boolean)
      * isNumber(s, 0, s.length(), false)}.
      */
-    public static boolean isNumber(CharSequence s) {
-        return isNumber(s, 0, s.length(), false);
+    public static boolean isNumber(CharSequence text) {
+        return isNumber(text, 0, text.length(), false);
     }
     
     /**
@@ -436,8 +450,8 @@ public class NumberBuilder implements NumberText { // NOPMD
      * <p>Convenience for {@link #isNumber(CharSequence, int, int, boolean)
      * isNumber(s, 0, s.length(), isInteger)}.
      */
-    public static boolean isNumber(CharSequence s, boolean isNonFractional) {
-        return isNumber(s, 0, s.length(), isNonFractional);
+    public static boolean isNumber(CharSequence text, boolean isNonFractional) {
+        return isNumber(text, 0, text.length(), isNonFractional);
     }
     
     /**
@@ -445,45 +459,41 @@ public class NumberBuilder implements NumberText { // NOPMD
      *
      * <p>Convenience for {@link #isNumber(CharSequence, int, int, boolean)}
      * isNumber(s, 0, stop, false)}.
-     * @param s a valid CharSequence
+     * @param text a valid CharSequence
      * @param start an index
      * @param stop an index
      * @return true if the CharSequence is a JSON&#x2192;URL number
      */
-    public static boolean isNumber(CharSequence s, int start, int stop) {
-        return isNumber(s, start, stop, false);
+    public static boolean isNumber(CharSequence text, int start, int stop) {
+        return isNumber(text, start, stop, false);
     }
 
     /**
      * Determine if the given CharSequence is a valid JSON&#x2192;URL number literal.
      * 
-     * @param s a valid CharSequence
+     * @param text a valid CharSequence
      * @param start an index
      * @param stop an index
      * @return true if the CharSequence is a JSON&#x2192;URL number
      */
-    @SuppressWarnings({
-        "PMD.CyclomaticComplexity",
-        "PMD.DataflowAnomalyAnalysis",
-        "PMD.NPathComplexity"})
-    public static boolean isNumber(
-            CharSequence s,
+    public static boolean isNumber(//NOPMD
+            CharSequence text,
             int start,
             int stop,
             boolean isNonFractional) {
 
-        int pos = start;
+        int pos = start; //NOPMD - DataflowAnomalyAnalysis
 
-        char c = s.charAt(start);
+        char c = text.charAt(start); //NOPMD
 
-        if (c == '-') {
+        if (c == MINUS) {
             pos++;
 
             if (pos == stop) {
                 return false;
             }
 
-            c = s.charAt(pos);
+            c = text.charAt(pos);
         }
 
         switch (c) {
@@ -499,22 +509,22 @@ public class NumberBuilder implements NumberText { // NOPMD
         case '7':
         case '8':
         case '9':
-            pos = digits(s, pos + 1, stop);
+            pos = digits(text, pos + 1, stop);
             break;
         default:
             return false;
         }
 
-        if (hasFract(pos, stop, s)) {
+        if (hasFract(text, pos, stop)) {
             if (isNonFractional) {
                 return false;
             }
-            pos = digits(s, pos + 1, stop);
+            pos = digits(text, pos + 1, stop);
         }
 
-        switch (getExponentType(s, pos, stop)) { // NOPMD - fall-through
+        switch (getExponentType(text, pos, stop)) { // NOPMD - fall-through
         case JUST_VALUE:
-            pos = digits(s, pos + 1, stop);
+            pos = digits(text, pos + 1, stop);
             break;
         case NEGATIVE_VALUE:
             if (isNonFractional) {
@@ -522,7 +532,7 @@ public class NumberBuilder implements NumberText { // NOPMD
             }
             // fall-through
         case POSITIVE_VALUE:
-            pos = digits(s, pos + 2, stop);
+            pos = digits(text, pos + 2, stop);
             break;
         case NONE:
             break;
@@ -547,8 +557,8 @@ public class NumberBuilder implements NumberText { // NOPMD
      *<p>Convenience for {@link #isNumber(CharSequence, int, int, boolean)
      * isNumber(s, 0, s.length(), true)}.
      */
-    public static boolean isNonFractional(CharSequence s) {
-        return isNumber(s, 0, s.length(), true);
+    public static boolean isNonFractional(CharSequence text) {
+        return isNumber(text, 0, text.length(), true);
     }
 
     /**
@@ -557,8 +567,8 @@ public class NumberBuilder implements NumberText { // NOPMD
      *<p>Convenience for {@link #isNumber(CharSequence, int, int, boolean)
      * isNumber(s, start, stop, true)}.
      */
-    public static boolean isNonFractional(CharSequence s, int start, int stop) {
-        return isNumber(s, start, stop, true);
+    public static boolean isNonFractional(CharSequence text, int start, int stop) {
+        return isNumber(text, start, stop, true);
     }
 
     /**
@@ -571,11 +581,11 @@ public class NumberBuilder implements NumberText { // NOPMD
     /**
      * Parse the given NumberText as a J2SE double.
      */
-    public static final double toDouble(NumberText t) {
+    public static final double toDouble(NumberText num) {
         char[] chars = toChars(
-                t.getText(),
-                t.getStartIndex(),
-                t.getStopIndex());
+                num.getText(),
+                num.getStartIndex(),
+                num.getStopIndex());
 
         return Double.parseDouble(new String(chars));
     }
@@ -584,16 +594,18 @@ public class NumberBuilder implements NumberText { // NOPMD
      * Parse the given NumberText as a {@link java.math.BigDecimal}.
      */
     public static final BigDecimal toBigDecimal(
-            NumberText t,
+            NumberText num,
             BigMathProvider mcp) {
 
-        char[] s = toChars(
-                t.getText(),
-                t.getStartIndex(),
-                t.getStopIndex());
+        char[] str = toChars(
+                num.getText(),
+                num.getStartIndex(),
+                num.getStopIndex());
 
-        MathContext mc = mcp == null ? null : mcp.getMathContext();
-        return mc == null ? new BigDecimal(s) : new BigDecimal(s, mc);
+        MathContext mctxt = mcp == null ? null : mcp.getMathContext();
+
+        return mctxt == null
+                ? new BigDecimal(str) : new BigDecimal(str, mctxt);
     }
 
     /**
@@ -634,13 +646,13 @@ public class NumberBuilder implements NumberText { // NOPMD
      * Convenience for {@link #build(NumberText, boolean, BigMathProvider)
      * build(t, false, mcp)}.
      * 
-     * @param t a valid NumberText
+     * @param num a valid NumberText
      * @param mcp a valid BigMathProvider or null
      */
     public static final Number build(
-            NumberText t,
+            NumberText num,
             BigMathProvider mcp) {
-        return build(t, false, mcp);
+        return build(num, false, mcp);
     }
 
     /**
@@ -648,13 +660,13 @@ public class NumberBuilder implements NumberText { // NOPMD
      * Convenience for {@link #build(NumberText, boolean, BigMathProvider)
      * build(t, primitiveOnly, null)}.
      * 
-     * @param t a valid NumberText
+     * @param num a valid NumberText
      * @param primitiveOnly return a Long or Double
      */
     public static final Number build(
-            NumberText t,
+            NumberText num,
             boolean primitiveOnly) {
-        return build(t, primitiveOnly, null);
+        return build(num, primitiveOnly, null);
     }
 
     /**
@@ -665,38 +677,37 @@ public class NumberBuilder implements NumberText { // NOPMD
      * logic to return a Number tailored to the value itself. For example, if
      * the value can be represented as a {@link Long} then it will be.
      *
-     * @param t a valid NumberText
+     * @param num a valid NumberText
      * @param primitiveOnly return a Long or Double
      * @param mcp a valid BigMathProvider or null
      * @return an instance of java.lang.Number
      */
     public static final Number build(
-            NumberText t, 
+            NumberText num, 
             boolean primitiveOnly,
             BigMathProvider mcp) {
 
-        if (!t.hasFractionalPart()) {
-            switch (t.getExponentType()) { //NOPMD - no default
+        if (!num.hasFractionalPart()) {
+            switch (num.getExponentType()) { //NOPMD - no default
             case NEGATIVE_VALUE:
                 break;
             case JUST_VALUE:
             case POSITIVE_VALUE:
             case NONE:
-                return toNonFractional(t, primitiveOnly, mcp);
+                return toNonFractional(num, primitiveOnly, mcp);
             }
         }
 
-        return primitiveOnly ? toDouble(t) : toBigDecimal(t, mcp);
+        return primitiveOnly ? toDouble(num) : toBigDecimal(num, mcp);
     }
 
     /**
      * Calculate an overflow value.
      */
-    @SuppressWarnings("PMD.CyclomaticComplexity")
-    private static final Number getOverflow(
+    private static Number getOverflow(//NOPMD
         String strLimit,
         Double infinity,
-        String s,
+        String text,
         int digitCount,
         BigMathProvider mcp) {
 
@@ -711,7 +722,7 @@ public class NumberBuilder implements NumberText { // NOPMD
         }
 
         boolean isOver = digitCount > strLimit.length()
-            || s.compareTo(strLimit) > 0;
+            || text.compareTo(strLimit) > 0;
             
         if (!isOver) {
             // close, but still within limit
@@ -725,17 +736,18 @@ public class NumberBuilder implements NumberText { // NOPMD
             throw new LimitException(MSG_LIMIT_INTEGER);
         }
 
-        switch (overOp) { // NOPMD - no default case
+        switch (overOp) { //NOPMD - SwitchStmtsShouldHaveDefault
         case DOUBLE:
-            return Double.valueOf(s);
+            return Double.valueOf(text);
         case BIG_DECIMAL:
             //
             // I don't have to check for mcp == null here as the
             // check above ensures that, if it's null, I'll throw
             // an exception before I get here.
             //
-            MathContext mc = mcp.getMathContext();
-            return mc == null ? new BigDecimal(s) : new BigDecimal(s, mc);
+            MathContext mctxt = mcp.getMathContext();
+            return mctxt == null
+                    ? new BigDecimal(text) : new BigDecimal(text, mctxt);
         case INFINITY:
             return infinity;
         }
@@ -746,36 +758,36 @@ public class NumberBuilder implements NumberText { // NOPMD
     /**
      * get the value of the exponent in {@code t}.
      */
-    private static final int getExponentValue(NumberText t) {
-        return t.getExponentType() == null ? 0 : parseInteger(
-            t.getText(),
-            t.getExponentStartIndex(),
-            t.getExponentStopIndex(),
+    private static int getExponentValue(NumberText num) {
+        return num.getExponentType() == null ? 0 : parseInteger(
+            num.getText(),
+            num.getExponentStartIndex(),
+            num.getExponentStopIndex(),
             0);
     }
     
     /**
      * Test if the given NumberText can be stored in a {@code long}.
-     * @param t a valid NumberText
+     * @param num a valid NumberText
      */
-    public static final boolean isLong(NumberText t) {
-        if (!t.isNonFractional()) {
+    public static final boolean isLong(NumberText num) {
+        if (!num.isNonFractional()) {
             return false;
         }
-        final int expValue = getExponentValue(t);
-        final int intIndexStart = t.getIntegerStartIndex();
-        final int intIndexStop = t.getIntegerStopIndex();
+        final int expValue = getExponentValue(num);
+        final int intIndexStart = num.getIntegerStartIndex();
+        final int intIndexStop = num.getIntegerStopIndex();
         final int digitCount = (intIndexStop - intIndexStart) + expValue;
 
         return isLong(
-            t.getText(),
+            num.getText(),
             intIndexStart,
             intIndexStop,
             digitCount,
-            t.isNegative());
+            num.isNegative());
     }
     
-    private static final boolean isLong(
+    private static boolean isLong(
         CharSequence text,
         int start,
         int stop,
@@ -793,8 +805,8 @@ public class NumberBuilder implements NumberText { // NOPMD
         final String s = isneg ? LONG_BOUNDARY_NEG : LONG_BOUNDARY_POS; // NOPMD
         
         for (int i = start, j = 0; i < stop; i++, j++) { // NOPMD
-            char a = text.charAt(i);
-            char b = s.charAt(j);
+            char a = text.charAt(i); // NOPMD
+            char b = s.charAt(j); // NOPMD
             
             if (a < b) {
                 return true;
@@ -815,20 +827,20 @@ public class NumberBuilder implements NumberText { // NOPMD
      * if the number is a valid long value. Otherwise, you may trigger an
      * exception or get a nonsense result.
      *
-     * @param t a valid NumberText
+     * @param num a valid NumberText
      */
-    public static final long toLong(NumberText t) {
+    public static final long toLong(NumberText num) {
         return toLong(
-            t.getText(),
-            t.getStartIndex(),
-            t.getIntegerStopIndex(),
-            getExponentValue(t));
+            num.getText(),
+            num.getStartIndex(),
+            num.getIntegerStopIndex(),
+            getExponentValue(num));
     }
 
     /**
      * Convert the given CharSequence to a long value.
      */
-    private static final long toLong(
+    private static long toLong(
             CharSequence text,
             int start,
             int stop,
@@ -839,21 +851,18 @@ public class NumberBuilder implements NumberText { // NOPMD
     /**
      * Attempt to build a non-fractional Number from the given NumberText.
      */
-    @SuppressWarnings({
-        "PMD.CyclomaticComplexity",
-        "PMD.NPathComplexity"})
-    private static final Number toNonFractional(
-            NumberText t,
+    private static Number toNonFractional(
+            NumberText num,
             boolean primitiveOnly,
             BigMathProvider mcp) {
 
-        final CharSequence text = t.getText();
+        final CharSequence text = num.getText();
 
-        final int expValue = getExponentValue(t);
-        final int intIndexStart = t.getIntegerStartIndex();
-        final int intIndexStop = t.getIntegerStopIndex();
+        final int expValue = getExponentValue(num);
+        final int intIndexStart = num.getIntegerStartIndex();
+        final int intIndexStop = num.getIntegerStopIndex();
         final int digitCount = (intIndexStop - intIndexStart) + expValue;
-        final boolean isneg = t.isNegative();
+        final boolean isneg = num.isNegative();
 
         if (isLong(text, intIndexStart, intIndexStop, digitCount, isneg)) {
             //
@@ -861,7 +870,7 @@ public class NumberBuilder implements NumberText { // NOPMD
             //
             return Long.valueOf(toLong(
                 text,
-                t.getStartIndex(),
+                num.getStartIndex(),
                 intIndexStop,
                 expValue));
         }
@@ -870,20 +879,20 @@ public class NumberBuilder implements NumberText { // NOPMD
             //
             // only option left
             //
-            return toDouble(t);
+            return toDouble(num);
         }
 
         final char[] chars = toChars(
                 text,
-                t.getStartIndex(),
+                num.getStartIndex(),
                 intIndexStop);
 
-        final String s = new String(chars);
+        final String str = new String(chars);
 
         final Number overflow = getOverflow(
             mcp == null ? null : mcp.getBigIntegerBoundary(isneg),
             isneg ? NEGATIVE_INFINITY : POSITIVE_INFINITY,
-            s,
+            str,
             digitCount,
             mcp);
 
@@ -891,7 +900,7 @@ public class NumberBuilder implements NumberText { // NOPMD
             return overflow;
         }
 
-        BigInteger ret = new BigInteger(s);
+        BigInteger ret = new BigInteger(str);
     
         if (expValue > 0) {
             ret = ret.multiply(BigInteger.TEN.pow(expValue));
@@ -909,13 +918,13 @@ public class NumberBuilder implements NumberText { // NOPMD
      * <p>Since this private, and I will never call this with a +/-
      * prefix, I've removed that logic.
      *
-     * @param s a non-null character sequence
+     * @param text a non-null character sequence
      * @param start start index
      * @param stop stop index
      * @return an integer
      */
     private static int parseInteger(
-            CharSequence s,
+            CharSequence text,
             int start,
             int stop,
             int defaultValue) {
@@ -927,8 +936,8 @@ public class NumberBuilder implements NumberText { // NOPMD
         int ret = 0;
         
         for (int i = start; i < stop; i++) {
-            char c = s.charAt(i);
-            ret = ret * 10 + (c - '0');
+            char cur = text.charAt(i);
+            ret = ret * 10 + (cur - '0');
         }
 
         return ret;
@@ -939,15 +948,14 @@ public class NumberBuilder implements NumberText { // NOPMD
      *
      * <p>This is similar to {@link java.lang.Long#parseLong(String)},
      * however, it accepts a bounded CharSequence and default value.
-     * @param s a non-null character sequence
+     * @param text a non-null character sequence
      * @param start start index
      * @param stop stop index
      * @return a long
      */
-    @SuppressWarnings("PMD.DataflowAnomalyAnalysis")
     private static long parseLong(
-            CharSequence s,
-            int start,
+            CharSequence text,
+            int start, // NOPMD
             int stop,
             int defaultValue) {
         
@@ -956,15 +964,16 @@ public class NumberBuilder implements NumberText { // NOPMD
         }
 
         long ret = 0;
-        boolean isneg = false;
+        boolean isneg = false; // NOPMD
 
-        char c = s.charAt(start);
+        char c = text.charAt(start); // NOPMD
         
-        switch (c) { // NOPMD - fall through
-        case '-':
+        switch (c) {
+        case MINUS:
             isneg = true;
-            // fall through
-        case '+':
+            start++;
+            break;
+        case PLUS:
             start++;
             break;
         default:
@@ -972,7 +981,7 @@ public class NumberBuilder implements NumberText { // NOPMD
         }
         
         for (int i = start; i < stop; i++) {
-            c = s.charAt(i);
+            c = text.charAt(i);
             ret = ret * 10 + (c - '0');
         }
 
@@ -999,13 +1008,15 @@ public class NumberBuilder implements NumberText { // NOPMD
                 text.getStopIndex());
     }
     
-    @SuppressWarnings("PMD.DataflowAnomalyAnalysis")
-    private static final char[] toChars(CharSequence s, int start, int stop) {
+    @SuppressWarnings({
+        "PMD.DataflowAnomalyAnalysis",
+        "PMD.ForLoopVariableCount"})
+    private static char[] toChars(CharSequence text, int start, int stop) {
         final int len = stop - start;
         final char[] ret = new char[len];
 
-        for (int i = start, j = 0; i < stop; i++, j++) { // NOPMD - ForLoopVariableCount
-            ret[j] = s.charAt(i);
+        for (int i = start, j = 0; i < stop; i++, j++) { 
+            ret[j] = text.charAt(i);
         }
         
         return ret;

--- a/module/jsonurl-core/src/main/java/org/jsonurl/NumberCoercionMap.java
+++ b/module/jsonurl-core/src/main/java/org/jsonurl/NumberCoercionMap.java
@@ -1,5 +1,3 @@
-package org.jsonurl;
-
 /*
  * Copyright 2019 David MacCormack
  * 
@@ -16,6 +14,8 @@ package org.jsonurl;
  * specific language governing permissions and limitations
  * under the License.
  */
+
+package org.jsonurl;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
@@ -55,14 +55,14 @@ import java.util.concurrent.atomic.LongAdder;
  *      <td>{@link java.lang.Double Double}</td></tr>
  * </table>
  */
-final class NumberCoercionMap {
+final class NumberCoercionMap { //NOPMD - ClassNamingConventions
 
     /**
      * Static map of input type to coerced type.
      */
-    @SuppressWarnings("PMD") // this is read-only
-    private static final Map<Class<? extends Number>, Class<? extends Number>> MAP =
-            new HashMap<>();
+    private static final Map<
+            Class<? extends Number>,
+            Class<? extends Number>> MAP = new HashMap<>();
 
     static {
         MAP.put(Byte.class, Long.class);
@@ -85,11 +85,11 @@ final class NumberCoercionMap {
 
     /**
      * Get the coerced type for the given input type.
-     * @param c a valid class
+     * @param clazz a valid class
      * @return a valid class
      */
-    public static final Class<? extends Number> getType(Class<? extends Number> c) {
-        Class<? extends Number> ret = MAP.get(c);
+    public static Class<? extends Number> getType(Class<? extends Number> clazz) {
+        Class<? extends Number> ret = MAP.get(clazz);
         return ret == null ? BigDecimal.class : ret;
     }
 }

--- a/module/jsonurl-core/src/main/java/org/jsonurl/NumberText.java
+++ b/module/jsonurl-core/src/main/java/org/jsonurl/NumberText.java
@@ -1,7 +1,5 @@
-package org.jsonurl;
-
 /*
- * Copyright 2019 David MacCormack
+ * Copyright 2019-2020 David MacCormack
  * 
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy
@@ -16,6 +14,8 @@ package org.jsonurl;
  * specific language governing permissions and limitations
  * under the License.
  */
+
+package org.jsonurl;
 
 /**
  * NumberText provides access to a parsed JSON&#x2192;URL number literal.
@@ -33,7 +33,7 @@ public interface NumberText {
     /**
      * type of parsed exponent string.
      */
-    public enum Exponent {
+    enum Exponent {
         NONE,
         JUST_VALUE,
         POSITIVE_VALUE,
@@ -43,52 +43,52 @@ public interface NumberText {
     /**
      * Get the input/parsed text.
      */
-    public CharSequence getText();
+    CharSequence getText();
 
     /**
      * Get the start index of the number's integer part.
      */
-    public int getIntegerStartIndex();
+    int getIntegerStartIndex();
 
     /**
      * Get the stop index of the number's integer part.
      */
-    public int getIntegerStopIndex();
+    int getIntegerStopIndex();
 
     /**
      * Get the start index of the number's fractional part.
      */
-    public int getFractionalStartIndex();
+    int getFractionalStartIndex();
 
     /**
      * Get the stop index of the number's fractional part.
      */
-    public int getFractionalStopIndex();
+    int getFractionalStopIndex();
 
     /**
      * Get the start index of the number's exponent part.
      */
-    public int getExponentStartIndex();
+    int getExponentStartIndex();
 
     /**
      * Get the stop index of the number's exponent part.
      */
-    public int getExponentStopIndex();
+    int getExponentStopIndex();
 
     /**
      * Get the start index of the number (inside {@link #getText()}.
      */
-    public int getStartIndex();
+    int getStartIndex();
 
     /**
      * Get the stop index of the number (inside {@link #getText()}.
      */
-    public int getStopIndex();
+    int getStopIndex();
 
     /**
      * Get the parsed exponent's type.
      */
-    public Exponent getExponentType();
+    Exponent getExponentType();
 
     /**
      * Test if this text holds a negative number.

--- a/module/jsonurl-core/src/main/java/org/jsonurl/ParseException.java
+++ b/module/jsonurl-core/src/main/java/org/jsonurl/ParseException.java
@@ -1,5 +1,3 @@
-package org.jsonurl;
-
 /*
  * Copyright 2019 David MacCormack
  * 
@@ -16,6 +14,8 @@ package org.jsonurl;
  * specific language governing permissions and limitations
  * under the License.
  */
+
+package org.jsonurl;
 
 /**
  * An exception that occurs while parsing JSON&#x2192;URL text.
@@ -63,18 +63,18 @@ public class ParseException extends RuntimeException {
 
     @Override
     public String toString() {
-        StringBuilder sb = new StringBuilder(64);
+        StringBuilder buf = new StringBuilder(64);
 
-        sb.append("jsonurl ")
+        buf.append("jsonurl ")
             .append(typeDescription())
             .append(": ")
             .append(getMessage());
 
-        int p = getPosition();
-        if (p > -1) {
-            sb.append(" at ").append(p);
+        int pos = getPosition();
+        if (pos > -1) {
+            buf.append(" at ").append(pos);
         }
 
-        return sb.toString();
+        return buf.toString();
     }
 }

--- a/module/jsonurl-core/src/main/java/org/jsonurl/ParseResultFacade.java
+++ b/module/jsonurl-core/src/main/java/org/jsonurl/ParseResultFacade.java
@@ -28,7 +28,7 @@ interface ParseResultFacade<R> {
     /**
      * Set the current parse location.
      */
-    ParseResultFacade<R> setLocation(int location);
+    ParseResultFacade<R> setLocation(int location); // NOPMD - LinguisticNaming
     
     /**
      * Get a top-level empty composite.
@@ -68,18 +68,22 @@ interface ParseResultFacade<R> {
     /**
      * Add the given literal.
      */
-    void addLiteral(CharSequence s, int start, int stop, boolean isEmptyUnquotedStringOK);
+    void addLiteral(
+            CharSequence text,
+            int start,
+            int stop,
+            boolean isEmptyUnquotedStringOK);
     
     /**
      * Add a single element array.
      */
     default void addSingleElementArray(
-            CharSequence s,
+            CharSequence text,
             int start,
             int stop,
             boolean isEmptyUnquotedStringOK) {
         beginArray();
-        addLiteral(s, start, stop, isEmptyUnquotedStringOK);
+        addLiteral(text, start, stop, isEmptyUnquotedStringOK);
         endArray();
     }
     
@@ -87,7 +91,7 @@ interface ParseResultFacade<R> {
      * Add object key.
      */
     void addObjectKey(
-        CharSequence s,
+        CharSequence text,
         int start,
         int stop,
         boolean isEmptyUnquotedStringOK);
@@ -110,7 +114,11 @@ interface ParseResultFacade<R> {
     /**
      * Get a top-level literal result.
      */
-    R getResult(CharSequence s, int start, int stop, boolean isEmptyUnquotedStringOK);
+    R getResult(
+            CharSequence text,
+            int start,
+            int stop,
+            boolean isEmptyUnquotedStringOK);
 
     /**
      * Test if the given result is valid.

--- a/module/jsonurl-core/src/main/java/org/jsonurl/Parser.java
+++ b/module/jsonurl-core/src/main/java/org/jsonurl/Parser.java
@@ -54,11 +54,7 @@ import java.util.Set;
  * @author David MacCormack
  * @since 2019-09-01
  */
-@SuppressWarnings({
-    "PMD.CyclomaticComplexity",
-    "PMD.GodClass",
-    "PMD.ExcessiveClassLength"})
-public class Parser {
+public class Parser { //NOPMD
 
     /**
      * Parse state.
@@ -113,6 +109,36 @@ public class Parser {
      * Maximum number of parsed values.
      */
     private int maxParseValues = DEFAULT_MAX_PARSE_VALUES;
+
+    /**
+     * begin-composite (open paren).
+     */
+    private static final char BEGIN_COMPOSITE = '(';
+
+    /**
+     * end-composite (close paren).
+     */
+    private static final char END_COMPOSITE = ')';
+
+    /**
+     * name-separator (colon).
+     */
+    private static final char NAME_SEPARATOR = ':';
+
+    /**
+     * value-separator (comma).
+     */
+    private static final char VALUE_SEPARATOR = ',';
+
+    /**
+     * x-www-form-urlencoded name-separator (equals).
+     */
+    private static final char WFU_NAME_SEPARATOR = '=';
+
+    /**
+     * x-www-form-urlencoded value-separator (ampersand).
+     */
+    private static final char WFU_VALUE_SEPARATOR = '&';
 
     /**
      * Allow application/x-www-form-urlencoded style separators.
@@ -186,9 +212,9 @@ public class Parser {
     /**
      * Returns true if application/x-www-form-urlencoded style separators are
      * allowed for an implied top-level object or array.
-     * @see #setAllowFormUrlEncoded(boolean) 
+     * @see #setFormUrlEncodedAllowed(boolean) 
      */
-    public boolean getAllowFormUrlEncoded() {
+    public boolean isFormUrlEncodedAllowed() {
         return wwwFormUrlEncoded;
     }
 
@@ -199,15 +225,15 @@ public class Parser {
      * 
      * @param wwwFormUrlEncoded true or false
      */
-    public void setAllowFormUrlEncoded(boolean wwwFormUrlEncoded) {
+    public void setFormUrlEncodedAllowed(boolean wwwFormUrlEncoded) {
         this.wwwFormUrlEncoded = wwwFormUrlEncoded;
     }
 
     /**
      * Returns true if the parser accepts empty, unquoted keys.
-     * @see #setAllowEmptyUnquotedKey(boolean) 
+     * @see #setEmptyUnquotedKeyAllowed(boolean) 
      */
-    public boolean getAllowEmptyUnquotedKey() {
+    public boolean isEmptyUnquotedKeyAllowed() {
         return allowEmptyUnquotedKey;
     }
 
@@ -216,15 +242,15 @@ public class Parser {
      * For example, {@code (:value)}.
      * @param allow boolean
      */
-    public void setAllowEmptyUnquotedKey(boolean allow) {
+    public void setEmptyUnquotedKeyAllowed(boolean allow) {
         this.allowEmptyUnquotedKey = allow;
     }
 
     /**
      * Returns true if the parser accepts empty, unquoted values.
-     * @see #setAllowEmptyUnquotedValue(boolean) 
+     * @see #setEmptyUnquotedValueAllowed(boolean) 
      */
-    public boolean getAllowEmptyUnquotedValue() {
+    public boolean isEmptyUnquotedValueAllowed() {
         return allowEmptyUnquotedValue;
     }
 
@@ -233,7 +259,7 @@ public class Parser {
      * For example, {@code (1,,3)}.
      * @param allow boolean
      */
-    public void setAllowEmptyUnquotedValue(boolean allow) {
+    public void setEmptyUnquotedValueAllowed(boolean allow) {
         this.allowEmptyUnquotedValue = allow;
     }
 
@@ -253,9 +279,9 @@ public class Parser {
             M extends V,
             N extends V,
             S extends V> J parseObject(
-                CharSequence s,
+                CharSequence text,
                 ValueFactory<V,C,ABT,A,JBT,J,B,M,N,S> factory) {
-        return (J)parse(s, 0, s.length(), TYPE_VALUE_OBJECT, factory);
+        return (J)parse(text, 0, text.length(), TYPE_VALUE_OBJECT, factory);
     }
 
     /**
@@ -274,11 +300,11 @@ public class Parser {
             M extends V,
             N extends V,
             S extends V> J parseObject(
-                CharSequence s,
+                CharSequence text,
                 int off,
                 int length,
                 ValueFactory<V,C,ABT,A,JBT,J,B,M,N,S> factory) {
-        return (J)parse(s, off, length, TYPE_VALUE_OBJECT, factory);
+        return (J)parse(text, off, length, TYPE_VALUE_OBJECT, factory);
     }
 
     /**
@@ -297,11 +323,11 @@ public class Parser {
             M extends V,
             N extends V,
             S extends V> J parseObject(
-                CharSequence s,
+                CharSequence text,
                 ValueFactory<V,C,ABT,A,JBT,J,B,M,N,S> factory,
                 JBT impliedObject) {
 
-        return (J)parse(s, 0, s.length(), TYPE_VALUE_OBJECT,
+        return (J)parse(text, 0, text.length(), TYPE_VALUE_OBJECT,
             new ValueFactoryParseResultFacade<>(factory, null, impliedObject));
     }
 
@@ -321,13 +347,13 @@ public class Parser {
             M extends V,
             N extends V,
             S extends V> J parseObject(
-                CharSequence s,
+                CharSequence text,
                 int off,
                 int length,
                 ValueFactory<V,C,ABT,A,JBT,J,B,M,N,S> factory,
                 JBT impliedObject) {
 
-        return (J)parse(s, off, length, TYPE_VALUE_OBJECT,
+        return (J)parse(text, off, length, TYPE_VALUE_OBJECT,
             new ValueFactoryParseResultFacade<>(factory, null, impliedObject));
     }
 
@@ -347,10 +373,10 @@ public class Parser {
             M extends V,
             N extends V,
             S extends V> A parseArray(
-                CharSequence s,
+                CharSequence text,
                 ValueFactory<V,C,ABT,A,JBT,J,B,M,N,S> factory) {
 
-        return (A)parse(s, 0, s.length(), TYPE_VALUE_ARRAY, factory);
+        return (A)parse(text, 0, text.length(), TYPE_VALUE_ARRAY, factory);
     }
 
     /**
@@ -369,11 +395,11 @@ public class Parser {
             M extends V,
             N extends V,
             S extends V> A parseArray(
-                CharSequence s,
+                CharSequence text,
                 int off,
                 int length,
                 ValueFactory<V,C,ABT,A,JBT,J,B,M,N,S> factory) {
-        return (A)parse(s, off, length, TYPE_VALUE_ARRAY, factory);
+        return (A)parse(text, off, length, TYPE_VALUE_ARRAY, factory);
     }
 
     /**
@@ -392,11 +418,11 @@ public class Parser {
             M extends V,
             N extends V,
             S extends V> A parseArray(
-                CharSequence s,
+                CharSequence text,
                 ValueFactory<V,C,ABT,A,JBT,J,B,M,N,S> factory,
                 ABT impliedArray) {
 
-        return (A)parse(s, 0, s.length(), TYPE_VALUE_ARRAY,
+        return (A)parse(text, 0, text.length(), TYPE_VALUE_ARRAY,
             new ValueFactoryParseResultFacade<>(factory, impliedArray, null));
     }
 
@@ -416,13 +442,13 @@ public class Parser {
             M extends V,
             N extends V,
             S extends V> A parseArray(
-                CharSequence s,
+                CharSequence text,
                 int off,
                 int length,
                 ValueFactory<V,C,ABT,A,JBT,J,B,M,N,S> factory,
                 ABT impliedArray) {
 
-        return (A)parse(s, off, length, TYPE_VALUE_ARRAY,
+        return (A)parse(text, off, length, TYPE_VALUE_ARRAY,
             new ValueFactoryParseResultFacade<>(factory, impliedArray, null));
     }
 
@@ -441,9 +467,9 @@ public class Parser {
             M extends V,
             N extends V,
             S extends V> V parse(
-                CharSequence s,
+                CharSequence text,
                 ValueFactory<V,C,ABT,A,JBT,J,B,M,N,S> factory) {
-        return parse(s, 0, s.length(), (EnumSet<ValueType>)null, factory);
+        return parse(text, 0, text.length(), (EnumSet<ValueType>)null, factory);
     }
 
     /**
@@ -461,11 +487,11 @@ public class Parser {
             M extends V,
             N extends V,
             S extends V> V parse(
-                CharSequence s,
+                CharSequence text,
                 int off,
                 int length,
                 ValueFactory<V,C,ABT,A,JBT,J,B,M,N,S> factory) {
-        return parse(s, off, length, (EnumSet<ValueType>)null, factory);
+        return parse(text, off, length, (EnumSet<ValueType>)null, factory);
     }
 
     /**
@@ -483,12 +509,12 @@ public class Parser {
             M extends V,
             N extends V,
             S extends V> V parse(
-                CharSequence s,
+                CharSequence text,
                 int off,
                 int length,
                 ValueType canReturn,
                 ValueFactory<V,C,ABT,A,JBT,J,B,M,N,S> factory) {
-        return parse(s, off, length, EnumSet.of(canReturn), factory);
+        return parse(text, off, length, EnumSet.of(canReturn), factory);
     }
 
     /**
@@ -506,10 +532,10 @@ public class Parser {
             M extends V,
             N extends V,
             S extends V> V parse(
-                CharSequence s,
+                CharSequence text,
                 ValueType canReturn,
                 ValueFactory<V,C,ABT,A,JBT,J,B,M,N,S> factory) {
-        return parse(s, 0, s.length(), EnumSet.of(canReturn), factory);
+        return parse(text, 0, text.length(), EnumSet.of(canReturn), factory);
     }
 
     /**
@@ -522,7 +548,7 @@ public class Parser {
      * to limit what types are allowed in the response. If an invalid value
      * type is found then a {@link ParseException} will be thrown.
      *
-     * @param s the text to be parsed
+     * @param text the text to be parsed
      * @param off offset of the first character to be parsed
      * @param length a <em>length</em>, not an offset
      * @param canReturn set of allowed return types
@@ -539,13 +565,13 @@ public class Parser {
             M extends V,
             N extends V,
             S extends V> V parse(
-                CharSequence s,
+                CharSequence text,
                 int off,
                 int length,
                 Set<ValueType> canReturn,
                 ValueFactory<V,C,ABT,A,JBT,J,B,M,N,S> factory) {
 
-        return parse(s, off, length, canReturn,
+        return parse(text, off, length, canReturn,
             new ValueFactoryParseResultFacade<>(factory, null, null));
     }
 
@@ -556,13 +582,17 @@ public class Parser {
      * call.
      */
     @SuppressWarnings({
-        "PMD.NPathComplexity",
-        "PMD.ExcessiveMethodLength",
-        "PMD.DataflowAnomalyAnalysis",
         "PMD.AvoidDuplicateLiterals",
+        "PMD.CyclomaticComplexity",
+        "PMD.DataflowAnomalyAnalysis",
+        "PMD.ModifiedCyclomaticComplexity",
+        "PMD.NcssCount",
+        "PMD.NcssMethodCount",
+        "PMD.NPathComplexity",
+        "PMD.StdCyclomaticComplexity",
         "PMD.SwitchDensity"})
     private <R> R parse(
-            CharSequence s,
+            CharSequence text,
             int off,
             int length,
             final Set<ValueType> canReturn,
@@ -589,7 +619,7 @@ public class Parser {
             // literals then return one.
             //
             if (allowEmptyUnquotedValue) {
-                return result.getResult(s, off, off, true);
+                return result.getResult(text, off, off, true);
             }
             
             //
@@ -629,7 +659,14 @@ public class Parser {
             stateStack.push(State.IN_ARRAY);
             isDoneTypeCheck = true;
 
-        } else if (s.charAt(off) != '(') {
+        } else if (text.charAt(off) == BEGIN_COMPOSITE) {
+            //
+            // composite and no implied object/array
+            //
+            stateStack.push(State.PAREN);
+            pos++;
+
+        } else {
             //
             // not composite; parse as a single literal value
             //
@@ -640,13 +677,12 @@ public class Parser {
             // structural characters) but not valid when inside a composite.
             // I don't think I want that.
             //
-            int litlen = parseLiteralLength(s, off, stop, null);
+            int litlen = parseLiteralLength(text, off, stop, null);
             if (litlen != length) {
-                throw new SyntaxException(
-                    MSG_EXPECT_LITERAL);
+                throw new SyntaxException(MSG_EXPECT_LITERAL);
             }
 
-            R ret = result.getResult(s, off, stop, allowEmptyUnquotedValue);
+            R ret = result.getResult(text, off, stop, allowEmptyUnquotedValue);
 
             if (canReturn != null && !result.isValid(canReturn, ret)) {
                 throw new SyntaxException(
@@ -658,12 +694,6 @@ public class Parser {
 
             return ret;
 
-        } else {
-            //
-            // composite and no implied object/array
-            //
-            stateStack.push(State.PAREN);
-            pos++;
         }
         
         final boolean allowEmptyUnquotedKey = this.allowEmptyUnquotedKey;
@@ -677,12 +707,12 @@ public class Parser {
                 throw new SyntaxException(MSG_STILL_OPEN, pos);
             }
 
-            char c = s.charAt(pos);
+            char c = text.charAt(pos); // NOPMD - ShortVariable
 
             switch (stateStack.peek()) { // NOPMD -- no switch default
             case PAREN:
                 switch (c) {
-                case '(':
+                case BEGIN_COMPOSITE:
                     //
                     // found two back-to-back open parens. We know the first,
                     // paren is starting an array.
@@ -780,7 +810,7 @@ public class Parser {
                 // paren followed by a literal.  I need to lookahead
                 // one token to see if this is an object or array.
                 //
-                int litlen = parseLiteralLength(s, pos, stop, MSG_STILL_OPEN);
+                int litlen = parseLiteralLength(text, pos, stop, MSG_STILL_OPEN);
 
                 parseValueCount = incrementLimit(
                         MSG_LIMIT_MAX_PARSE_VALUES,
@@ -788,22 +818,23 @@ public class Parser {
                         parseValueCount,
                         pos);
 
-                int litpos = pos;
+                int litpos = pos; // NOPMD - capture the literal's position
+
                 pos += litlen;
 
                 if (pos == stop) {
                     throw new SyntaxException(MSG_STILL_OPEN, pos);
                 }
 
-                c = s.charAt(pos);
+                c = text.charAt(pos);
 
                 switch (c) {
-                case '&':
+                case WFU_VALUE_SEPARATOR:
                     if (!wwwFormUrlEncoded || parseDepth != 1) {
                         throw new SyntaxException(MSG_BAD_CHAR, pos);
                     }
                     // fall through
-                case ',':
+                case VALUE_SEPARATOR:
                     //
                     // multi-element array
                     //
@@ -829,11 +860,11 @@ public class Parser {
                     result
                         .setLocation(litpos)
                         .beginArray()
-                        .addLiteral(s, litpos, pos, allowEmptyUnquotedValue);
+                        .addLiteral(text, litpos, pos, allowEmptyUnquotedValue);
 
                     continue;
 
-                case ')':
+                case END_COMPOSITE:
                     //
                     // single element array
                     //
@@ -851,7 +882,7 @@ public class Parser {
                     
                     result
                         .setLocation(litpos)
-                        .addSingleElementArray(s, litpos, pos, allowEmptyUnquotedValue);
+                        .addSingleElementArray(text, litpos, pos, allowEmptyUnquotedValue);
 
                     parseDepth--;
                     pos++;
@@ -888,12 +919,12 @@ public class Parser {
                     stateStack.pop();
                     continue;
 
-                case '=':
+                case WFU_NAME_SEPARATOR:
                     if (!wwwFormUrlEncoded || parseDepth != 1) {
                         throw new SyntaxException(MSG_BAD_CHAR, pos);
                     }
                     // fall through
-                case ':':
+                case NAME_SEPARATOR:
                     //
                     // key name for object
                     //
@@ -913,7 +944,7 @@ public class Parser {
                     result
                         .setLocation(litpos)
                         .beginObject()
-                        .addObjectKey(s, litpos, pos, allowEmptyUnquotedKey);
+                        .addObjectKey(text, litpos, pos, allowEmptyUnquotedKey);
 
                     pos++;
                     continue;
@@ -924,7 +955,7 @@ public class Parser {
                 throw new SyntaxException(MSG_EXPECT_LITERAL, pos);
 
             case IN_ARRAY:
-                if (c == '(') {
+                if (c == BEGIN_COMPOSITE) {
                     stateStack.set(0, State.ARRAY_AFTER_ELEMENT);
                     stateStack.push(State.PAREN);
 
@@ -938,7 +969,7 @@ public class Parser {
                 }
 
                 litpos = pos;
-                litlen = parseLiteralLength(s, pos, stop, MSG_STILL_OPEN);
+                litlen = parseLiteralLength(text, pos, stop, MSG_STILL_OPEN);
 
                 parseValueCount = incrementLimit(
                         MSG_LIMIT_MAX_PARSE_VALUES,
@@ -951,7 +982,7 @@ public class Parser {
                 stateStack.set(0, State.ARRAY_AFTER_ELEMENT);
                 result
                     .setLocation(litpos)
-                    .addLiteral(s, litpos, pos, allowEmptyUnquotedValue);
+                    .addLiteral(text, litpos, pos, allowEmptyUnquotedValue);
 
                 if (pos == stop) {
                     if (parseDepth == 1 && impliedArray) {
@@ -966,17 +997,17 @@ public class Parser {
                 result.setLocation(pos).addArrayElement();
 
                 switch (c) {
-                case '&':
+                case WFU_VALUE_SEPARATOR:
                     if (!wwwFormUrlEncoded || parseDepth != 1) {
                         throw new SyntaxException(MSG_BAD_CHAR, pos);
                     }
                     // fall through
-                case ',':
+                case VALUE_SEPARATOR:
                     stateStack.set(0, State.IN_ARRAY);
                     pos++;
                     continue;
 
-                case ')':
+                case END_COMPOSITE:
                     result.endArray();
 
                     parseDepth--;
@@ -1014,7 +1045,7 @@ public class Parser {
                 throw new SyntaxException(MSG_EXPECT_STRUCT_CHAR, pos);
 
             case OBJECT_HAVE_KEY:
-                if (c == '(') {
+                if (c == BEGIN_COMPOSITE) {
                     stateStack.set(0, State.OBJECT_AFTER_ELEMENT);
                     stateStack.push(State.PAREN);
 
@@ -1029,7 +1060,7 @@ public class Parser {
                 }
 
                 litpos = pos;
-                litlen = parseLiteralLength(s, pos, stop, MSG_STILL_OPEN);
+                litlen = parseLiteralLength(text, pos, stop, MSG_STILL_OPEN);
 
                 parseValueCount = incrementLimit(
                         MSG_LIMIT_MAX_PARSE_VALUES,
@@ -1042,7 +1073,7 @@ public class Parser {
                 stateStack.set(0, State.OBJECT_AFTER_ELEMENT);
                 result
                     .setLocation(litpos)
-                    .addLiteral(s, litpos, pos, allowEmptyUnquotedValue);
+                    .addLiteral(text, litpos, pos, allowEmptyUnquotedValue);
                 
                 if (pos == stop) {
                     if (parseDepth == 1 && impliedObject) {
@@ -1058,17 +1089,17 @@ public class Parser {
                 result.setLocation(pos).addObjectElement();
 
                 switch (c) {
-                case '&':
+                case WFU_VALUE_SEPARATOR:
                     if (!wwwFormUrlEncoded || parseDepth != 1) {
                         throw new SyntaxException(MSG_BAD_CHAR, pos);
                     }
                     // fall through
-                case ',':
+                case VALUE_SEPARATOR:
                     stateStack.set(0, State.IN_OBJECT);
                     pos++;
                     continue;
 
-                case ')':
+                case END_COMPOSITE:
                     result.endObject();
 
                     parseDepth--;
@@ -1106,22 +1137,22 @@ public class Parser {
 
             case IN_OBJECT:
                 litpos = pos;
-                litlen = parseLiteralLength(s, pos, stop, MSG_STILL_OPEN);
+                litlen = parseLiteralLength(text, pos, stop, MSG_STILL_OPEN);
                 pos += litlen;
 
                 if (pos == stop) {
                     throw new SyntaxException(MSG_STILL_OPEN, pos);
                 }
 
-                c = s.charAt(pos);
+                c = text.charAt(pos);
 
                 switch (c) {
-                case '=':
+                case WFU_NAME_SEPARATOR:
                     if (!wwwFormUrlEncoded || parseDepth != 1) {
                         throw new SyntaxException(MSG_BAD_CHAR, pos);
                     }
                     // fall through
-                case ':':
+                case NAME_SEPARATOR:
                     break;
 
                 default:
@@ -1132,7 +1163,7 @@ public class Parser {
 
                 result
                     .setLocation(litpos)
-                    .addObjectKey(s, litpos, pos, allowEmptyUnquotedKey);
+                    .addObjectKey(text, litpos, pos, allowEmptyUnquotedKey);
 
                 pos++;
                 continue;
@@ -1143,16 +1174,17 @@ public class Parser {
     /**
      * increment a limit value, throwing an exception if the limit is reached.
      */
-    private static final int incrementLimit(
+    private static int incrementLimit(
             LimitException.Message msg,
             int limit,
             int value,
             int pos) {
-        value++;
 
-        if (value > limit) {
+        final int newValue = value + 1;
+
+        if (newValue > limit) {
             throw new LimitException(msg, pos);
         }
-        return value;
+        return newValue;
     }
 }

--- a/module/jsonurl-core/src/main/java/org/jsonurl/SyntaxException.java
+++ b/module/jsonurl-core/src/main/java/org/jsonurl/SyntaxException.java
@@ -1,5 +1,3 @@
-package org.jsonurl;
-
 /*
  * Copyright 2019 David MacCormack
  * 
@@ -16,6 +14,8 @@ package org.jsonurl;
  * specific language governing permissions and limitations
  * under the License.
  */
+
+package org.jsonurl;
 
 /**
  * A syntax error in JSON&#x2192;URL text. 
@@ -74,7 +74,7 @@ public class SyntaxException extends ParseException {
 
         private final String text;
 
-        private Message(String text) {
+        Message(String text) {
             this.text = text;
         }
 
@@ -89,7 +89,7 @@ public class SyntaxException extends ParseException {
     /**
      * My message.
      */
-    private final Message message;
+    private final Message message; // NOPMD - not a bean
 
     /**
      * Create a new SyntaxException.

--- a/module/jsonurl-core/src/main/java/org/jsonurl/ValueFactory.java
+++ b/module/jsonurl-core/src/main/java/org/jsonurl/ValueFactory.java
@@ -43,9 +43,9 @@ import java.util.Set;
 public interface ValueFactory<
         V,
         C extends V,
-        ABT,
+        ABT, // NOPMD - GenericsNaming
         A extends C,
-        JBT,
+        JBT, // NOPMD - GenericsNaming
         J extends C,
         B extends V,
         M extends V,
@@ -76,7 +76,7 @@ public interface ValueFactory<
      * @author David MacCormack
      * @since 2019-09-01
      */
-    public interface TransparentBuilder<
+    interface TransparentBuilder<
         V,
         C extends V,
         A extends C,
@@ -111,7 +111,7 @@ public interface ValueFactory<
      * @param <N> null type
      * @param <S> string type
      */
-    public interface BigMathFactory<
+    interface BigMathFactory<
         V,
         C extends V,
         ABT,
@@ -133,7 +133,7 @@ public interface ValueFactory<
      * JSON&#x2192;URL spec.
      * @return a valid composite instance
      */
-    public C getEmptyComposite();
+    C getEmptyComposite();
 
     /**
      * construct a new JSON array from the given builder.
@@ -145,7 +145,7 @@ public interface ValueFactory<
      * @param builder an array builder
      * @return a valid JSON array
      */
-    public A newArray(ABT builder);
+    A newArray(ABT builder);
     
     /**
      * construct a new JSON object from the given builder.
@@ -157,7 +157,7 @@ public interface ValueFactory<
      * @param builder an object builder
      * @return a valid JSON object
      */
-    public J newObject(JBT builder);
+    J newObject(JBT builder);
     
     /**
      * get a new JSON array builder.
@@ -167,7 +167,7 @@ public interface ValueFactory<
      * a new JSON array builder.
      * @return a valid JSON array builder
      */
-    public ABT newArrayBuilder();
+    ABT newArrayBuilder();
 
     /**
      * get a new JSON object builder.
@@ -177,17 +177,17 @@ public interface ValueFactory<
      * a new JSON object builder.
      * @return a valid JSON object builder
      */
-    public JBT newObjectBuilder();
+    JBT newObjectBuilder();
 
     /**
      * add a value to an array.
      */
-    public void add(ABT dest, V obj);
+    void add(ABT dest, V obj);
 
     /**
      * add a key/value pair to an object.
      */
-    public void put(JBT dest, String key, V value);
+    void put(JBT dest, String key, V value);
 
     /**
      * get the null value.
@@ -196,7 +196,7 @@ public interface ValueFactory<
      * the JSON value null.
      * @return a valid null instance
      */
-    public N getNull();
+    N getNull();
 
     /**
      * get the true value.
@@ -205,7 +205,7 @@ public interface ValueFactory<
      * the JSON boolean value true.
      * @return the JSON value true
      */
-    public B getTrue();
+    B getTrue();
 
     /**
      * get the true value.
@@ -214,22 +214,22 @@ public interface ValueFactory<
      * the JSON boolean value false.
      * @return the JSON value false
      */
-    public B getFalse();
+    B getFalse();
     
     /**
      * get a JSON string value.
      *
      * @return a valid string whose text is the given character sequence
      */
-    public S getString(CharSequence s, int start, int stop);
+    S getString(CharSequence text, int start, int stop);
 
     /**
      * get a JSON string value.
      *
      * @return a valid string whose text is the given Java String
      */
-    default S getString(String s) {
-        return getString(s, 0, s.length());
+    default S getString(String text) {
+        return getString(text, 0, text.length());
     }
 
     /**
@@ -238,16 +238,16 @@ public interface ValueFactory<
      * @param text the parsed text of a JSON&#x2192;URL number literal 
      * @return a number object for the given text
      */
-    public M getNumber(NumberText text);
+    M getNumber(NumberText text);
 
     /**
      * Get a boolean value.
      *
-     * @param b a boolean value
+     * @param value a boolean value
      * @return if <i>b</i> is true then return true; otherwise, return false.
      */
-    default B getBoolean(boolean b) {
-        return b ? getTrue() : getFalse();
+    default B getBoolean(boolean value) {
+        return value ? getTrue() : getFalse();
     }
 
     /**
@@ -267,7 +267,7 @@ public interface ValueFactory<
      * @param value value to test
      * @return true if the type of value is in the given types set.
      */
-    public boolean isValid(Set<ValueType> types, V value);
+    boolean isValid(Set<ValueType> types, V value);
 
     /**
      * Test if the given object is the empty composite value.
@@ -292,32 +292,31 @@ public interface ValueFactory<
     /**
      * get a true, false, or null value for the given text.
      *
-     * @param s the text
+     * @param text the text
      * @param start the start index
      * @param stop the stop index
      * @return a valid value or null
      */
-    @SuppressWarnings("PMD")
-    default V getTrueFalseNull(
-            CharSequence s,
+    default V getTrueFalseNull(// NOPMD - CyclomaticComplexity
+            CharSequence text,
             int start,
             int stop) {
 
         switch (stop - start) {
         case 4:
-            switch (s.charAt(start)) {
+            switch (text.charAt(start)) {
             case 't':
-                if (s.charAt(start + 1) != 'r'
-                        || s.charAt(start + 2) != 'u'
-                        || s.charAt(start + 3) != 'e') {
+                if (text.charAt(start + 1) != 'r'
+                        || text.charAt(start + 2) != 'u'
+                        || text.charAt(start + 3) != 'e') {
                     return null;
                 }
                 return getTrue();
 
             case 'n':
-                if (s.charAt(start + 1) != 'u'
-                        || s.charAt(start + 2) != 'l'
-                        || s.charAt(start + 3) != 'l') {
+                if (text.charAt(start + 1) != 'u'
+                        || text.charAt(start + 2) != 'l'
+                        || text.charAt(start + 3) != 'l') {
                     return null;
                 }
                 return getNull();
@@ -329,11 +328,11 @@ public interface ValueFactory<
             // fall through
 
         case 5:
-            if (s.charAt(start) != 'f'
-                    || s.charAt(start + 1) != 'a'
-                    || s.charAt(start + 2) != 'l'
-                    || s.charAt(start + 3) != 's'
-                    || s.charAt(start + 4) != 'e') {
+            if (text.charAt(start) != 'f'
+                    || text.charAt(start + 1) != 'a'
+                    || text.charAt(start + 2) != 'l'
+                    || text.charAt(start + 3) != 's'
+                    || text.charAt(start + 4) != 'e') {
                 return null;
             }
             return getFalse();

--- a/module/jsonurl-core/src/main/java/org/jsonurl/ValueFactoryParseResultFacade.java
+++ b/module/jsonurl-core/src/main/java/org/jsonurl/ValueFactoryParseResultFacade.java
@@ -31,9 +31,9 @@ import java.util.Set;
  */
 class ValueFactoryParseResultFacade<V,
         C extends V,
-        ABT,
+        ABT, // NOPMD - GenericsNaming
         A extends C,
-        JBT,
+        JBT, // NOPMD - GenericsNaming
         J extends C,
         B extends V,
         M extends V,
@@ -115,8 +115,8 @@ class ValueFactoryParseResultFacade<V,
     @Override
     public ParseResultFacade<V> endArray() {
         @SuppressWarnings("unchecked") //NOPMD
-        ABT ab = (ABT)builderStack.pop();
-        factoryValueStack.push(factory.newArray(ab));
+        ABT builder = (ABT)builderStack.pop();
+        factoryValueStack.push(factory.newArray(builder));
         return this;
     }
 
@@ -129,8 +129,8 @@ class ValueFactoryParseResultFacade<V,
     @Override
     public ParseResultFacade<V> endObject() {
         @SuppressWarnings("unchecked")
-        JBT jb = (JBT)builderStack.pop();
-        factoryValueStack.push(factory.newObject(jb));
+        JBT builder = (JBT)builderStack.pop();
+        factoryValueStack.push(factory.newObject(builder));
         return this;
     }
 
@@ -146,37 +146,37 @@ class ValueFactoryParseResultFacade<V,
 
     @Override
     public void addLiteral(
-            CharSequence s,
+            CharSequence text,
             int start,
             int stop,
             boolean isEmptyUnquotedStringOK) {
 
         factoryValueStack.push(
-            literal(buf, numb, s, start, stop, factory, isEmptyUnquotedStringOK));
+            literal(buf, numb, text, start, stop, factory, isEmptyUnquotedStringOK));
     }
 
     @Override
     public void addSingleElementArray(
-            CharSequence s,
+            CharSequence text,
             int start,
             int stop,
             boolean isEmptyUnquotedStringOK) {
         ABT sea = factory.newArrayBuilder();
 
         factory.add(sea, literal(
-            buf, numb, s, start, stop, factory, isEmptyUnquotedStringOK));
+            buf, numb, text, start, stop, factory, isEmptyUnquotedStringOK));
 
         factoryValueStack.push(factory.newArray(sea));                
     }
 
     @Override
     public void addObjectKey(
-            CharSequence s,
+            CharSequence text,
             int start,
             int stop,
             boolean isEmptyUnquotedStringOK) {
         keyStack.push(literalToJavaString(
-            buf, numb, s, start, stop, isEmptyUnquotedStringOK));                
+            buf, numb, text, start, stop, isEmptyUnquotedStringOK));                
     }
 
     @Override
@@ -196,9 +196,9 @@ class ValueFactoryParseResultFacade<V,
         String key = keyStack.pop();
 
         @SuppressWarnings("unchecked")
-        JBT jb = (JBT)builderStack.peek();
+        JBT builder = (JBT)builderStack.peek();
 
-        factory.put(jb, key, topval);
+        factory.put(builder, key, topval);
         return this;
     }
 
@@ -214,11 +214,11 @@ class ValueFactoryParseResultFacade<V,
 
     @Override
     public V getResult(
-            CharSequence s,
+            CharSequence text,
             int start,
             int stop,
             boolean isEmptyUnquotedStringOK) {
-        return literal(buf, numb, s, start, stop, factory, isEmptyUnquotedStringOK);
+        return literal(buf, numb, text, start, stop, factory, isEmptyUnquotedStringOK);
     }
 
     @Override

--- a/module/jsonurl-core/src/main/java/org/jsonurl/ValueFactoryParser.java
+++ b/module/jsonurl-core/src/main/java/org/jsonurl/ValueFactoryParser.java
@@ -46,15 +46,19 @@ import java.util.EnumSet;
 public class ValueFactoryParser<
         V,
         C extends V,
-        ABT,
+        ABT, // NOPMD - GenericsNaming
         A extends C,
-        JBT,
+        JBT, // NOPMD - GenericsNaming
         J extends C,
         B extends V,
         M extends V,
         N extends V,
         S extends V> extends Parser {
-    
+
+    /**
+     * This parser's ValueFactory.
+     */
+    private final ValueFactory<V,C,ABT,A,JBT,J,B,M,N,S> factory;
      
     /**
      * A {@link ValueFactoryParser} with {@link ValueFactory.TransparentBuilder
@@ -89,11 +93,6 @@ public class ValueFactoryParser<
             super(factory);
         }
     }
-    
-    /**
-     * This parser's ValueFactory.
-     */
-    private final ValueFactory<V,C,ABT,A,JBT,J,B,M,N,S> factory;
 
     /**
      * Instantiate a new ValueFactoryParser.
@@ -108,8 +107,8 @@ public class ValueFactoryParser<
      * {@link org.jsonurl.Parser#parseObject(CharSequence, int, int, ValueFactory)
      * parse(s, 0, s.length(), getFactory())}.
      */
-    public J parseObject(CharSequence s) {
-        return parseObject(s, 0, s.length(), factory);
+    public J parseObject(CharSequence text) {
+        return parseObject(text, 0, text.length(), factory);
     }
 
     /**
@@ -117,8 +116,8 @@ public class ValueFactoryParser<
      * {@link org.jsonurl.Parser#parseObject(CharSequence, int, int, ValueFactory)
      * parse(s, off, length, getFactory())}.
      */
-    public J parseObject(CharSequence s, int off, int length) {
-        return super.parseObject(s, off, length, factory);
+    public J parseObject(CharSequence text, int off, int length) {
+        return super.parseObject(text, off, length, factory);
     }
 
     /**
@@ -126,8 +125,8 @@ public class ValueFactoryParser<
      * {@link org.jsonurl.Parser#parseObject(CharSequence, int, int, ValueFactory, Object)
      * parse(s, 0, s.length(), getFactory(), impliedObject)}.
      */
-    public J parseObject(CharSequence s, JBT impliedObject) {
-        return super.parseObject(s, factory, impliedObject);
+    public J parseObject(CharSequence text, JBT impliedObject) {
+        return super.parseObject(text, factory, impliedObject);
     }
 
     /**
@@ -136,11 +135,11 @@ public class ValueFactoryParser<
      * parse(s, off, length, getFactory(), impliedObject)}.
      */
     public J parseObject(
-                CharSequence s,
+                CharSequence text,
                 int off,
                 int length,
                 JBT impliedObject) {
-        return super.parseObject(s, off, length, factory, impliedObject);
+        return super.parseObject(text, off, length, factory, impliedObject);
     }
 
     /**
@@ -148,8 +147,8 @@ public class ValueFactoryParser<
      * {@link org.jsonurl.Parser#parseArray(CharSequence, int, int, ValueFactory)
      * parse(s, 0, s.length(), getFactory())}.
      */
-    public A parseArray(CharSequence s) {
-        return super.parseArray(s, 0, s.length(), factory);
+    public A parseArray(CharSequence text) {
+        return super.parseArray(text, 0, text.length(), factory);
     }
 
     /**
@@ -157,8 +156,8 @@ public class ValueFactoryParser<
      * {@link org.jsonurl.Parser#parseArray(CharSequence, int, int, ValueFactory)
      * parse(s, off, length, getFactory())}.
      */
-    public A parseArray(CharSequence s, int off, int length) {
-        return super.parseArray(s, off, length, factory);
+    public A parseArray(CharSequence text, int off, int length) {
+        return super.parseArray(text, off, length, factory);
     }
 
     /**
@@ -166,8 +165,8 @@ public class ValueFactoryParser<
      * {@link org.jsonurl.Parser#parseArray(CharSequence, int, int, ValueFactory, Object)
      * parse(s, 0, s.length(), getFactory())}.
      */
-    public A parseArray(CharSequence s, ABT impliedArray) {
-        return super.parseArray(s, 0, s.length(), factory, impliedArray);
+    public A parseArray(CharSequence text, ABT impliedArray) {
+        return super.parseArray(text, 0, text.length(), factory, impliedArray);
     }
 
     /**
@@ -176,11 +175,11 @@ public class ValueFactoryParser<
      * parse(s, off, length, getFactory())}.
      */
     public A parseArray(
-                CharSequence s,
+                CharSequence text,
                 int off,
                 int length,
                 ABT impliedArray) {
-        return super.parseArray(s, off, length, factory, impliedArray);
+        return super.parseArray(text, off, length, factory, impliedArray);
     }
 
     /**
@@ -188,8 +187,8 @@ public class ValueFactoryParser<
      * {@link #parse(CharSequence, int, int, ValueType, ValueFactory)
      * parse(s, 0, s.length(), null, factory)}.
      */
-    public V parse(CharSequence s) {
-        return parse(s, 0, s.length(), (EnumSet<ValueType>)null, factory);
+    public V parse(CharSequence text) {
+        return parse(text, 0, text.length(), (EnumSet<ValueType>)null, factory);
     }
 
     /**
@@ -197,8 +196,8 @@ public class ValueFactoryParser<
      * {@link #parse(CharSequence, int, int, ValueType, ValueFactory)
      * parse(s, off, length, null, factory)}.  
      */
-    public V parse(CharSequence s, int off, int length) {
-        return parse(s, off, length, (EnumSet<ValueType>)null, factory);
+    public V parse(CharSequence text, int off, int length) {
+        return parse(text, off, length, (EnumSet<ValueType>)null, factory);
     }
     
     /**
@@ -207,11 +206,11 @@ public class ValueFactoryParser<
      * parse(s, off, length, EnumSet.of(canReturn), factory)}.
      */
     public V parse(
-                CharSequence s,
+                CharSequence text,
                 int off,
                 int length,
                 ValueType canReturn) {
-        return parse(s, off, length, EnumSet.of(canReturn), factory);
+        return parse(text, off, length, EnumSet.of(canReturn), factory);
     }
 
     /**
@@ -219,8 +218,8 @@ public class ValueFactoryParser<
      * {@link #parse(CharSequence, int, int, ValueType, ValueFactory)
      * parse(s, 0, s.length(), EnumSet.of(canReturn), factory)}.
      */
-    public V parse(CharSequence s, ValueType canReturn) {
-        return parse(s, 0, s.length(), EnumSet.of(canReturn), factory);
+    public V parse(CharSequence text, ValueType canReturn) {
+        return parse(text, 0, text.length(), EnumSet.of(canReturn), factory);
     }
 
     /**

--- a/module/jsonurl-core/src/main/java/org/jsonurl/ValueType.java
+++ b/module/jsonurl-core/src/main/java/org/jsonurl/ValueType.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright 2020 David MacCormack
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package org.jsonurl;
 
 import java.util.Set;
@@ -18,7 +35,7 @@ public enum ValueType {
      */
     private final boolean isPrimitive;
 
-    private ValueType(boolean isPrimitive) {
+    ValueType(boolean isPrimitive) {
         this.isPrimitive = isPrimitive;
     }
 

--- a/module/jsonurl-core/src/main/java/org/jsonurl/j2se/JavaValueFactory.java
+++ b/module/jsonurl-core/src/main/java/org/jsonurl/j2se/JavaValueFactory.java
@@ -1,5 +1,3 @@
-package org.jsonurl.j2se;
-
 /*
  * Copyright 2019 David MacCormack
  *
@@ -16,6 +14,8 @@ package org.jsonurl.j2se;
  * specific language governing permissions and limitations
  * under the License.
  */
+
+package org.jsonurl.j2se;
 
 import java.math.MathContext;
 import java.util.ArrayList;
@@ -60,6 +60,43 @@ public interface JavaValueFactory extends ValueFactory<
         String> {
 
     /**
+     * The default null value.
+     */
+    Object NULL = new Object();
+
+    /**
+     * The default empty composite value.
+     */
+    Map<String,Object> EMPTY = Collections.emptyMap();
+
+    /**
+     * A singleton instance of {@link BigMathFactory} with 32-bit boundaries.
+     */
+    BigMathFactory BIGMATH32 = new BigMathFactory(
+        MathContext.DECIMAL32,
+        BigMath.BIG_INTEGER32_BOUNDARY_NEG,
+        BigMath.BIG_INTEGER32_BOUNDARY_POS,
+        null);
+    
+    /**
+     * A singleton instance of {@link BigMathFactory} with 64-bit boundaries.
+     */
+    BigMathFactory BIGMATH64 = new BigMathFactory(
+        MathContext.DECIMAL64,
+        BigMath.BIG_INTEGER64_BOUNDARY_NEG,
+        BigMath.BIG_INTEGER64_BOUNDARY_POS,
+        null);
+    
+    /**
+     * A singleton instance of {@link BigMathFactory} with 128-bit boundaries.
+     */
+    BigMathFactory BIGMATH128 = new BigMathFactory(
+        MathContext.DECIMAL128,
+        BigMath.BIG_INTEGER128_BOUNDARY_NEG,
+        BigMath.BIG_INTEGER128_BOUNDARY_POS,
+        null);
+
+    /**
      * A {@link org.jsonurl.ValueFactory ValueFactory} based on Java SE data
      * types that uses {@link java.math.BigInteger BigInteger} and
      * {@link java.math.BigDecimal BigDecimal} when necessary.
@@ -71,7 +108,7 @@ public interface JavaValueFactory extends ValueFactory<
      * {@link java.lang.Double Double} will be stored in a
      * {@link java.math.BigDecimal BigDecimal}.
      */
-    public static class BigMathFactory extends BigMath 
+    class BigMathFactory extends BigMath 
             implements JavaValueFactory,
                 ValueFactory.BigMathFactory<
                     Object,
@@ -87,18 +124,18 @@ public interface JavaValueFactory extends ValueFactory<
 
         /**
          * Create a new BigMathFactory JavaValueFactory using the given MathContext.
-         * @param mc a valid MathContext or null
+         * @param context a valid MathContext or null
          * @param bigIntegerBoundaryNeg negative value boundary
          * @param bigIntegerBoundaryPos positive value boundary
          * @param bigIntegerOverflow action on boundary overflow
          */
         public BigMathFactory(
-            MathContext mc,
+            MathContext context,
             String bigIntegerBoundaryNeg,
             String bigIntegerBoundaryPos,
             BigMath.BigIntegerOverflow bigIntegerOverflow) {
 
-            super(mc,
+            super(context,
                 bigIntegerBoundaryNeg,
                 bigIntegerBoundaryPos,
                 bigIntegerOverflow);
@@ -119,7 +156,7 @@ public interface JavaValueFactory extends ValueFactory<
      * and {@link Long#MAX_VALUE}, and  an instance of
      * {@link java.lang.Double Double} for everything else.
      */
-    public static final JavaValueFactory PRIMITIVE = new JavaValueFactory() {
+    JavaValueFactory PRIMITIVE = new JavaValueFactory() {
 
         @Override
         public Number getNumber(NumberText text) {
@@ -131,50 +168,13 @@ public interface JavaValueFactory extends ValueFactory<
      * A singleton instance of {@link JavaValueFactory} that uses instances of
      * {@link java.lang.Double Double} for all numbers.
      */
-    public static final JavaValueFactory DOUBLE = new JavaValueFactory() {
+    JavaValueFactory DOUBLE = new JavaValueFactory() {
 
         @Override
         public Number getNumber(NumberText text) {
             return Double.valueOf(text.toString());
         }
     };
-
-    /**
-     * A singleton instance of {@link BigMathFactory} with 32-bit boundaries.
-     */
-    public static final BigMathFactory BIGMATH32 = new BigMathFactory(
-        MathContext.DECIMAL32,
-        BigMath.BIG_INTEGER32_BOUNDARY_NEG,
-        BigMath.BIG_INTEGER32_BOUNDARY_POS,
-        null);
-    
-    /**
-     * A singleton instance of {@link BigMathFactory} with 64-bit boundaries.
-     */
-    public static final BigMathFactory BIGMATH64 = new BigMathFactory(
-        MathContext.DECIMAL64,
-        BigMath.BIG_INTEGER64_BOUNDARY_NEG,
-        BigMath.BIG_INTEGER64_BOUNDARY_POS,
-        null);
-    
-    /**
-     * A singleton instance of {@link BigMathFactory} with 128-bit boundaries.
-     */
-    public static final BigMathFactory BIGMATH128 = new BigMathFactory(
-        MathContext.DECIMAL128,
-        BigMath.BIG_INTEGER128_BOUNDARY_NEG,
-        BigMath.BIG_INTEGER128_BOUNDARY_POS,
-        null);
-
-    /**
-     * The default null value.
-     */
-    public static final Object NULL = new Object();
-
-    /**
-     * The default empty composite value.
-     */
-    public static final Map<String,Object> EMPTY = Collections.emptyMap();
 
     @Override
     default Object getEmptyComposite() {
@@ -238,13 +238,13 @@ public interface JavaValueFactory extends ValueFactory<
     }
 
     @Override
-    default String getString(CharSequence s, int start, int stop) {
-        return toJavaString(s, start, stop);
+    default String getString(CharSequence text, int start, int stop) {
+        return toJavaString(text, start, stop);
     }
 
     @Override
-    default String getString(String s) {
-        return s;
+    default String getString(String value) {
+        return value;
     }
 
     @Override
@@ -275,21 +275,21 @@ public interface JavaValueFactory extends ValueFactory<
 
     /**
      * Get a java.lang.String from a java.lang.CharSequence
-     * @param cs input
+     * @param text input
      * @param start start index
      * @param stop stop index
      * @return a valid String
      */
-    public static String toJavaString(CharSequence cs, int start, int stop) {
-        if (cs instanceof String) {
-            String s = (String)cs;
+    static String toJavaString(CharSequence text, int start, int stop) {
+        if (text instanceof String) {
+            String str = (String)text;
 
-            if (start == 0 && stop == cs.length()) {
-                return s;
+            if (start == 0 && stop == text.length()) {
+                return str;
             }
             
-            return s.substring(start, stop);
+            return str.substring(start, stop);
         }
-        return cs.subSequence(start, stop).toString();
+        return text.subSequence(start, stop).toString();
     }
 }

--- a/module/jsonurl-core/src/main/java/org/jsonurl/j2se/JsonUrlWriter.java
+++ b/module/jsonurl-core/src/main/java/org/jsonurl/j2se/JsonUrlWriter.java
@@ -1,5 +1,3 @@
-package org.jsonurl.j2se;
-
 /*
  * Copyright 2019 David MacCormack
  * 
@@ -17,6 +15,8 @@ package org.jsonurl.j2se;
  * under the License.
  */
 
+package org.jsonurl.j2se;
+
 import java.io.IOException;
 import java.util.Map;
 import org.jsonurl.JsonTextBuilder;
@@ -28,15 +28,14 @@ import org.jsonurl.JsonTextBuilder;
  * @author David MacCormack
  * @since 2020-09-01
  */
-@SuppressWarnings("PMD.GodClass")
-public final class JsonUrlWriter {
+public final class JsonUrlWriter { // NOPMD
     
     private JsonUrlWriter() {
         // EMPTY
     }
     
-    private static final boolean isNull(Object in) {
-        return in == null || in == JavaValueFactory.NULL;
+    private static boolean isNull(Object obj) {
+        return obj == null || obj == JavaValueFactory.NULL;
     }
 
     /**
@@ -44,78 +43,74 @@ public final class JsonUrlWriter {
      * 
      * @param <A> Accumulator type
      * @param <R> Result type
-     * @param out non-null JsonTextBuilder
-     * @param in null or Java Object
+     * @param dest non-null JsonTextBuilder
+     * @param value null or Java Object
      */
-    @SuppressWarnings({
-        "PMD.NPathComplexity",
-        "PMD.CyclomaticComplexity"
-    })
-    public static final <A,R> void write(
-            JsonTextBuilder<A,R> out,
-            Object in) throws IOException {
+    public static <A,R> void write(// NOPMD
+            JsonTextBuilder<A,R> dest,
+            Object value) throws IOException {
 
-        if (isNull(in)) {
-            out.addNull();
+        if (isNull(value)) {
+            dest.addNull();
             return;
         }
 
-        if (in instanceof Number) {
-            out.add((Number)in);
+        if (value instanceof Number) {
+            dest.add((Number)value);
             return;
         }
 
-        if (in instanceof Boolean) {
-            out.add(((Boolean)in).booleanValue());
+        if (value instanceof Boolean) {
+            dest.add(((Boolean)value).booleanValue());
             return;
         }
 
-        if (in instanceof Enum) {
-            out.add(((Enum<?>)in).name());
+        if (value instanceof Enum) {
+            dest.add(((Enum<?>)value).name());
             return;
         }
 
-        if (in instanceof Map) {
-            write(out, (Map<?,?>)in);
+        if (value instanceof Map) {
+            write(dest, (Map<?,?>)value);
             return;
         }
 
-        if (in instanceof Iterable) {
-            write(out, (Iterable<?>)in);
+        if (value instanceof Iterable) {
+            write(dest, (Iterable<?>)value);
             return;
         }
 
-        if (in instanceof CharSequence) {
-            out.add((CharSequence)in);
+        if (value instanceof CharSequence) {
+            dest.add((CharSequence)value);
             return;
         }
 
-        final Class<?> clazz = in.getClass();
+        final Class<?> clazz = value.getClass();
         if (clazz.isArray()) {
             Class<?> type = clazz.getComponentType();
             if (type == Boolean.TYPE) {
-                write(out, (boolean[])in);
+                write(dest, (boolean[])value);
             } else if (type == Byte.TYPE) {
-                write(out, (byte[])in);
+                write(dest, (byte[])value);
             } else if (type == Character.TYPE) {
-                write(out, (char[])in);
+                write(dest, (char[])value);
             } else if (type == Double.TYPE) {
-                write(out, (double[])in);
+                write(dest, (double[])value);
             } else if (type == Float.TYPE) {
-                write(out, (float[])in);
+                write(dest, (float[])value);
             } else if (type == Integer.TYPE) {
-                write(out, (int[])in);
+                write(dest, (int[])value);
             } else if (type == Long.TYPE) {
-                write(out, (long[])in);
+                write(dest, (long[])value);
             } else if (type == Short.TYPE) {
-                write(out, (short[])in);
+                write(dest, (short[])value);
             } else {
-                write(out, (Object[])in);
+                write(dest, (Object[])value);
             }
             return;
         }
 
-        throw new IOException("unsupported class: " + in.getClass());
+        throw new IOException("unsupported class: " + value.getClass());
     }
 
     /**
@@ -123,23 +118,23 @@ public final class JsonUrlWriter {
      * 
      * @param <A> Accumulator type
      * @param <R> Result type
-     * @param out non-null JsonTextBuilder
-     * @param in null or Java Object
+     * @param dest non-null JsonTextBuilder
+     * @param value null or Java Object
      */
-    public static final <A,R> void write(
-            JsonTextBuilder<A,R> out,
-            Map<?,?> in) throws IOException {
+    public static <A,R> void write(
+            JsonTextBuilder<A,R> dest,
+            Map<?,?> value) throws IOException {
         
-        if (isNull(in)) {
-            out.addNull();
+        if (isNull(value)) {
+            dest.addNull();
             return;
         }
 
-        out.beginObject();
+        dest.beginObject();
 
-        boolean comma = false; // NOPMD - I need to track this
+        boolean comma = false; // NOPMD - state across for loop
 
-        for (Map.Entry<?,?> e : in.entrySet())  {
+        for (Map.Entry<?,?> e : value.entrySet())  {
             Object key = e.getKey();
             
             if (!(key instanceof CharSequence)) {
@@ -147,17 +142,17 @@ public final class JsonUrlWriter {
             }
 
             if (comma) {
-                out.valueSeparator();
+                dest.valueSeparator();
             }
 
-            comma = true; // NOPMD - I need to track this
+            comma = true; // NOPMD - state across for loop
 
-            out.addKey(key.toString()).nameSeparator();
+            dest.addKey(key.toString()).nameSeparator();
 
-            write(out, e.getValue());
+            write(dest, e.getValue());
         }
 
-        out.endObject();
+        dest.endObject();
     }
 
     /**
@@ -165,33 +160,33 @@ public final class JsonUrlWriter {
      * 
      * @param <A> Accumulator type
      * @param <R> Result type
-     * @param out non-null JsonTextBuilder
-     * @param it null or an iterable object
+     * @param dest non-null JsonTextBuilder
+     * @param value null or an iterable object
      */
-    public static final <A,R> void write(
-            JsonTextBuilder<A,R> out,
-            Iterable<?> it) throws IOException {
+    public static <A,R> void write(
+            JsonTextBuilder<A,R> dest,
+            Iterable<?> value) throws IOException {
 
-        if (isNull(it)) {
-            out.addNull();
+        if (isNull(value)) {
+            dest.addNull();
             return;
         }
 
-        out.beginArray();
+        dest.beginArray();
 
-        boolean comma = false; // NOPMD - I need to track this
+        boolean comma = false; // NOPMD - state across for loop
 
-        for (Object obj : it) {
+        for (Object obj : value) {
             if (comma) {
-                out.valueSeparator();
+                dest.valueSeparator();
             }
 
-            comma = true; // NOPMD - I need to track this
+            comma = true; // NOPMD - state across for loop
 
-            write(out, obj);
+            write(dest, obj);
         }
 
-        out.endArray();
+        dest.endArray();
     }
 
     /**
@@ -199,28 +194,28 @@ public final class JsonUrlWriter {
      * 
      * @param <A> Accumulator type
      * @param <R> Result type
-     * @param out non-null JsonTextBuilder
+     * @param dest non-null JsonTextBuilder
      * @param array null or a valid array
      */
-    public static final <A,R> void write(
-            JsonTextBuilder<A,R> out,
+    public static <A,R> void write(
+            JsonTextBuilder<A,R> dest,
             boolean... array) throws IOException {
 
         if (isNull(array)) {
-            out.addNull();
+            dest.addNull();
             return;
         }
 
-        out.beginArray();
+        dest.beginArray();
 
         for (int i = 0; i < array.length; i++) {
             if (i > 0) {
-                out.valueSeparator();
+                dest.valueSeparator();
             }
-            out.add(array[i]);
+            dest.add(array[i]);
         }
 
-        out.endArray();
+        dest.endArray();
     }
 
     /**
@@ -228,28 +223,28 @@ public final class JsonUrlWriter {
      * 
      * @param <A> Accumulator type
      * @param <R> Result type
-     * @param out non-null JsonTextBuilder
+     * @param dest non-null JsonTextBuilder
      * @param array null or a valid array
      */
-    public static final <A,R> void write(
-            JsonTextBuilder<A,R> out,
+    public static <A,R> void write(
+            JsonTextBuilder<A,R> dest,
             byte... array) throws IOException {
 
         if (isNull(array)) {
-            out.addNull();
+            dest.addNull();
             return;
         }
 
-        out.beginArray();
+        dest.beginArray();
 
         for (int i = 0; i < array.length; i++) {
             if (i > 0) {
-                out.valueSeparator();
+                dest.valueSeparator();
             }
-            out.add(array[i]);
+            dest.add(array[i]);
         }
 
-        out.endArray();
+        dest.endArray();
     }
 
     /**
@@ -257,28 +252,28 @@ public final class JsonUrlWriter {
      * 
      * @param <A> Accumulator type
      * @param <R> Result type
-     * @param out non-null JsonTextBuilder
+     * @param dest non-null JsonTextBuilder
      * @param array null or a valid array
      */
-    public static final <A,R> void write(
-            JsonTextBuilder<A,R> out,
+    public static <A,R> void write(
+            JsonTextBuilder<A,R> dest,
             char... array) throws IOException {
 
         if (isNull(array)) {
-            out.addNull();
+            dest.addNull();
             return;
         }
 
-        out.beginArray();
+        dest.beginArray();
 
         for (int i = 0; i < array.length; i++) {
             if (i > 0) {
-                out.valueSeparator();
+                dest.valueSeparator();
             }
-            out.add(array[i]);
+            dest.add(array[i]);
         }
 
-        out.endArray();
+        dest.endArray();
     }
 
     /**
@@ -286,28 +281,28 @@ public final class JsonUrlWriter {
      * 
      * @param <A> Accumulator type
      * @param <R> Result type
-     * @param out non-null JsonTextBuilder
+     * @param dest non-null JsonTextBuilder
      * @param array null or a valid array
      */
-    public static final <A,R> void write(
-            JsonTextBuilder<A,R> out,
+    public static <A,R> void write(
+            JsonTextBuilder<A,R> dest,
             double... array) throws IOException {
 
         if (isNull(array)) {
-            out.addNull();
+            dest.addNull();
             return;
         }
 
-        out.beginArray();
+        dest.beginArray();
 
         for (int i = 0; i < array.length; i++) {
             if (i > 0) {
-                out.valueSeparator();
+                dest.valueSeparator();
             }
-            out.add(array[i]);
+            dest.add(array[i]);
         }
 
-        out.endArray();
+        dest.endArray();
     }
 
     /**
@@ -315,28 +310,28 @@ public final class JsonUrlWriter {
      * 
      * @param <A> Accumulator type
      * @param <R> Result type
-     * @param out non-null JsonTextBuilder
+     * @param dest non-null JsonTextBuilder
      * @param array null or a valid array
      */
-    public static final <A,R> void write(
-            JsonTextBuilder<A,R> out,
+    public static <A,R> void write(
+            JsonTextBuilder<A,R> dest,
             float... array) throws IOException {
 
         if (isNull(array)) {
-            out.addNull();
+            dest.addNull();
             return;
         }
 
-        out.beginArray();
+        dest.beginArray();
 
         for (int i = 0; i < array.length; i++) {
             if (i > 0) {
-                out.valueSeparator();
+                dest.valueSeparator();
             }
-            out.add(array[i]);
+            dest.add(array[i]);
         }
 
-        out.endArray();
+        dest.endArray();
     }
 
     /**
@@ -344,28 +339,28 @@ public final class JsonUrlWriter {
      * 
      * @param <A> Accumulator type
      * @param <R> Result type
-     * @param out non-null JsonTextBuilder
+     * @param dest non-null JsonTextBuilder
      * @param array null or a valid array
      */
-    public static final <A,R> void write(
-            JsonTextBuilder<A,R> out,
+    public static <A,R> void write(
+            JsonTextBuilder<A,R> dest,
             int... array) throws IOException {
 
         if (isNull(array)) {
-            out.addNull();
+            dest.addNull();
             return;
         }
 
-        out.beginArray();
+        dest.beginArray();
 
         for (int i = 0; i < array.length; i++) {
             if (i > 0) {
-                out.valueSeparator();
+                dest.valueSeparator();
             }
-            out.add(array[i]);
+            dest.add(array[i]);
         }
 
-        out.endArray();
+        dest.endArray();
     }
 
     /**
@@ -373,28 +368,28 @@ public final class JsonUrlWriter {
      * 
      * @param <A> Accumulator type
      * @param <R> Result type
-     * @param out non-null JsonTextBuilder
+     * @param dest non-null JsonTextBuilder
      * @param array null or a valid array
      */
-    public static final <A,R> void write(
-            JsonTextBuilder<A,R> out,
+    public static <A,R> void write(
+            JsonTextBuilder<A,R> dest,
             long... array) throws IOException {
 
         if (isNull(array)) {
-            out.addNull();
+            dest.addNull();
             return;
         }
 
-        out.beginArray();
+        dest.beginArray();
 
         for (int i = 0; i < array.length; i++) {
             if (i > 0) {
-                out.valueSeparator();
+                dest.valueSeparator();
             }
-            out.add(array[i]);
+            dest.add(array[i]);
         }
 
-        out.endArray();
+        dest.endArray();
     }
 
     /**
@@ -402,29 +397,29 @@ public final class JsonUrlWriter {
      * 
      * @param <A> Accumulator type
      * @param <R> Result type
-     * @param out non-null JsonTextBuilder
+     * @param dest non-null JsonTextBuilder
      * @param array null or a valid array
      */
-    @SuppressWarnings("PMD.AvoidUsingShortType")
-    public static final <A,R> void write(
-            JsonTextBuilder<A,R> out,
-            short... array) throws IOException {
+    public static <A,R> void write(
+            JsonTextBuilder<A,R> dest,
+            short... array) // NOPMD - AvoidUsingShortType
+                throws IOException {
 
         if (isNull(array)) {
-            out.addNull();
+            dest.addNull();
             return;
         }
 
-        out.beginArray();
+        dest.beginArray();
 
         for (int i = 0; i < array.length; i++) {
             if (i > 0) {
-                out.valueSeparator();
+                dest.valueSeparator();
             }
-            out.add(array[i]);
+            dest.add(array[i]);
         }
 
-        out.endArray();
+        dest.endArray();
     }
 
     /**
@@ -432,28 +427,28 @@ public final class JsonUrlWriter {
      * 
      * @param <A> Accumulator type
      * @param <R> Result type
-     * @param out non-null JsonTextBuilder
+     * @param dest non-null JsonTextBuilder
      * @param array null or a valid array
      */
-    public static final <A,R> void write(
-            JsonTextBuilder<A,R> out,
+    public static <A,R> void write(
+            JsonTextBuilder<A,R> dest,
             Object... array) throws IOException {
 
         if (isNull(array)) {
-            out.addNull();
+            dest.addNull();
             return;
         }
 
-        out.beginArray();
+        dest.beginArray();
 
         for (int i = 0; i < array.length; i++) {
             if (i > 0) {
-                out.valueSeparator();
+                dest.valueSeparator();
             }
-            write(out, array[i]);
+            write(dest, array[i]);
         }
 
-        out.endArray();
+        dest.endArray();
     }
 
 }

--- a/module/jsonurl-core/src/main/java/org/jsonurl/j2se/package-info.java
+++ b/module/jsonurl-core/src/main/java/org/jsonurl/j2se/package-info.java
@@ -1,18 +1,3 @@
-/**
- * This package provides an implementation of the JSON&#x2192;URL parser
- * based on Java SE datatypes.
- *
- * <p>The primary entry point for most use cases
- * {@link org.jsonurl.j2se.JsonUrlParser JsonUrlParser}, which implements a
- * JSON object model API to parse JSON&#x2192;URL text using Java SE types (e.g.
- * {@link java.util.Map Map}, {@link java.util.List List}, etc).
- * 
- * @author jsonurl.org
- * @author David MacCormack
- * @since 2019-09-01
- */
-package org.jsonurl.j2se;
-
 /*
  * Copyright 2019 David MacCormack
  * 
@@ -29,3 +14,18 @@ package org.jsonurl.j2se;
  * specific language governing permissions and limitations
  * under the License.
  */
+
+/**
+ * This package provides an implementation of the JSON&#x2192;URL parser
+ * based on Java SE datatypes.
+ *
+ * <p>The primary entry point for most use cases
+ * {@link org.jsonurl.j2se.JsonUrlParser JsonUrlParser}, which implements a
+ * JSON object model API to parse JSON&#x2192;URL text using Java SE types (e.g.
+ * {@link java.util.Map Map}, {@link java.util.List List}, etc).
+ * 
+ * @author jsonurl.org
+ * @author David MacCormack
+ * @since 2019-09-01
+ */
+package org.jsonurl.j2se;

--- a/module/jsonurl-core/src/main/java/org/jsonurl/package-info.java
+++ b/module/jsonurl-core/src/main/java/org/jsonurl/package-info.java
@@ -1,20 +1,3 @@
-/**
- * This package provides an extensible JSON&#x2192;URL parser core and
- * static utility methods.
- *
- * <p>If you need a parser bound to your own JSON model API then
- * a {@link org.jsonurl.ValueFactory ValueFactory} may be created and
- * supplied to an instance of {@link org.jsonurl.Parser Parser}. Otherwise,
- * if a parser based on J2SE datatypes is sufficient then
- * take a look at {@link org.jsonurl.j2se.JsonUrlParser JsonUrlParser} which
- * does just that. 
- * 
- * @author jsonurl.org
- * @author David MacCormack
- * @since 2019-09-01
- */
-package org.jsonurl;
-
 /*
  * Copyright 2019 David MacCormack
  * 
@@ -31,3 +14,20 @@ package org.jsonurl;
  * specific language governing permissions and limitations
  * under the License.
  */
+
+/**
+ * This package provides an extensible JSON&#x2192;URL parser core and
+ * static utility methods.
+ *
+ * <p>If you need a parser bound to your own JSON model API then
+ * a {@link org.jsonurl.ValueFactory ValueFactory} may be created and
+ * supplied to an instance of {@link org.jsonurl.Parser Parser}. Otherwise,
+ * if a parser based on J2SE datatypes is sufficient then
+ * take a look at {@link org.jsonurl.j2se.JsonUrlParser JsonUrlParser} which
+ * does just that. 
+ * 
+ * @author jsonurl.org
+ * @author David MacCormack
+ * @since 2019-09-01
+ */
+package org.jsonurl;

--- a/module/jsonurl-core/src/test/java/org/jsonurl/AbstractJsonTextBuilderTest.java
+++ b/module/jsonurl-core/src/test/java/org/jsonurl/AbstractJsonTextBuilderTest.java
@@ -19,6 +19,8 @@ package org.jsonurl;
 
 import static org.jsonurl.AbstractParseTest.makeImplied;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -38,9 +40,9 @@ import org.junit.jupiter.params.provider.ValueSource;
 public abstract class AbstractJsonTextBuilderTest<
     V,
     C extends V,
-    ABT, 
+    ABT, // NOPMD - GenericsNaming 
     A extends C,
-    JBT,
+    JBT, // NOPMD - GenericsNaming
     J extends C> {
 
     /**
@@ -50,10 +52,10 @@ public abstract class AbstractJsonTextBuilderTest<
     
     /**
      * Write the given value.
-     * @param out destination
+     * @param dest destination
      * @param value value to write
      */
-    protected abstract void write(JsonTextBuilder<?,?> out, V value)
+    protected abstract void write(JsonTextBuilder<?,?> dest, V value)
         throws IOException;
 
     /**
@@ -77,46 +79,46 @@ public abstract class AbstractJsonTextBuilderTest<
         "(()&false&null&true&1.0&(false,hello,world,(),2.0))",
     })
     void testArray(String text) throws IOException {
-        Parser p = new Parser();
+        Parser par = new Parser();
 
-        p.setAllowFormUrlEncoded(true);
-        assertEquals(true, p.getAllowFormUrlEncoded(), text);
+        par.setFormUrlEncodedAllowed(true);
+        assertTrue(par.isFormUrlEncodedAllowed(), text);
 
         //
         // !implied && wwwFormUrlEncoded
         //
-        A value = p.parseArray(text, factory);
+        A value = par.parseArray(text, factory);
         assertTest(text, value, false, true);
 
         //
         // implied && wwwFormUrlEncoded
         //
-        value = p.parseArray(
+        value = par.parseArray(
             makeImplied(text),
             factory,
             factory.newArrayBuilder());
 
         assertTest(makeImplied(text), value, true, true);
 
-        text = replaceWfuChars(text);
-        p.setAllowFormUrlEncoded(false);
-        assertEquals(false, p.getAllowFormUrlEncoded(), text);
+        final String wfuText = replaceWfuChars(text);
+        par.setFormUrlEncodedAllowed(false);
+        assertFalse(par.isFormUrlEncodedAllowed(), wfuText);
 
         //
         // !implied && !wwwFormUrlEncoded
         //
-        value = p.parseArray(text, factory);
-        assertTest(text, value, false, false);
+        value = par.parseArray(wfuText, factory);
+        assertTest(wfuText, value, false, false);
 
         //
         // implied && !wwwFormUrlEncoded
         //
-        value = p.parseArray(
-            makeImplied(text),
+        value = par.parseArray(
+            makeImplied(wfuText),
             factory,
             factory.newArrayBuilder());
 
-        assertTest(makeImplied(text), value, true, false);
+        assertTest(makeImplied(wfuText), value, true, false);
     }
     
     @ParameterizedTest
@@ -131,46 +133,46 @@ public abstract class AbstractJsonTextBuilderTest<
         "(1.234=false)",
     })
     void testObject(String text) throws IOException {
-        Parser p = new Parser();
+        Parser par = new Parser();
 
-        p.setAllowFormUrlEncoded(true);
-        assertEquals(true, p.getAllowFormUrlEncoded(), text);
+        par.setFormUrlEncodedAllowed(true);
+        assertTrue(par.isFormUrlEncodedAllowed(), text);
 
         //
         // !implied && wwwFormUrlEncoded
         //
-        J value = p.parseObject(text, factory);
+        J value = par.parseObject(text, factory);
         assertTest(text, value, false, true);
 
         //
         // implied && wwwFormUrlEncoded
         //
-        value = p.parseObject(
+        value = par.parseObject(
             makeImplied(text),
             factory,
             factory.newObjectBuilder());
 
         assertTest(makeImplied(text), value, true, true);
 
-        text = replaceWfuChars(text);
-        p.setAllowFormUrlEncoded(false);
-        assertEquals(false, p.getAllowFormUrlEncoded(), text);
+        final String wfuText = replaceWfuChars(text);
+        par.setFormUrlEncodedAllowed(false);
+        assertFalse(par.isFormUrlEncodedAllowed(), wfuText);
 
         //
         // !implied && !wwwFormUrlEncoded
         //
-        value = p.parseObject(text, factory);
-        assertTest(text, value, false, false);
+        value = par.parseObject(wfuText, factory);
+        assertTest(wfuText, value, false, false);
 
         //
         // implied && !wwwFormUrlEncoded
         //
-        value = p.parseObject(
-            makeImplied(text),
+        value = par.parseObject(
+            makeImplied(wfuText),
             factory,
             factory.newObjectBuilder());
 
-        assertTest(makeImplied(text), value, true, false);
+        assertTest(makeImplied(wfuText), value, true, false);
     }
 
     @ParameterizedTest
@@ -191,17 +193,17 @@ public abstract class AbstractJsonTextBuilderTest<
             boolean implied,
             boolean wwwFormUrlEncoded) throws IOException {
 
-        JsonUrlStringBuilder sb = new JsonUrlStringBuilder();
-        sb.setImplied(implied);
-        sb.setFormUrlEncoded(wwwFormUrlEncoded);
+        JsonUrlStringBuilder jsb = new JsonUrlStringBuilder();
+        jsb.setImplied(implied);
+        jsb.setFormUrlEncoded(wwwFormUrlEncoded);
 
-        write(sb, value);
+        write(jsb, value);
 
-        String actual = sb.build();
+        String actual = jsb.build();
         assertEquals(expected, actual, expected);
     }
     
-    private static final String replaceWfuChars(String s) {
-        return s.replace('&', ',').replace('=', ':');
+    private static String replaceWfuChars(String text) {
+        return text.replace('&', ',').replace('=', ':');
     }
 }

--- a/module/jsonurl-core/src/test/java/org/jsonurl/LimitExceptionTest.java
+++ b/module/jsonurl-core/src/test/java/org/jsonurl/LimitExceptionTest.java
@@ -32,7 +32,6 @@ import org.junit.jupiter.params.provider.EnumSource;
  */
 public class LimitExceptionTest {
 
-
     @ParameterizedTest
     @Tag("exception")
     @EnumSource(LimitException.Message.class)

--- a/module/jsonurl-core/src/test/java/org/jsonurl/NumberBuilderTest.java
+++ b/module/jsonurl-core/src/test/java/org/jsonurl/NumberBuilderTest.java
@@ -1,5 +1,3 @@
-package org.jsonurl;
-
 /*
  * Copyright 2019 David MacCormack
  * 
@@ -17,10 +15,12 @@ package org.jsonurl;
  * under the License.
  */
 
+package org.jsonurl;
 
-// CHECKSTYLE:OFF
-import static org.junit.jupiter.api.Assertions.*;
-// CHECKSTYLE:ON
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
@@ -40,7 +40,7 @@ import org.junit.jupiter.params.provider.ValueSource;
  * @author David MacCormack
  * @since 2019-09-01
  */
-class NumberBuilderTest {
+class NumberBuilderTest { // NOPMD
     /** Prefix used to test non-zero based start index. */
     private static final String PREFIX  = "prefix ";
     
@@ -67,57 +67,65 @@ class NumberBuilderTest {
     /** tag annotation. */
     public static final String TAG_BIG = "big";
 
-    private NumberBuilder newNumberBuilder(String s) {
+    private NumberBuilder newNumberBuilder(String text) {
         return new NumberBuilder(
-                PREFIX + s + SUFFIX,
+                PREFIX + text + SUFFIX,
                 PREFIX.length(),
-                PREFIX.length() + s.length());
+                PREFIX.length() + text.length());
     }
     
-    private void assertEquals_isNumber(boolean expect, String s) {
-        assertEquals(expect, NumberBuilder.isNumber(s), s);
-        assertEquals(expect, NumberBuilder.isNumber(s, false), s);
+    private void assertEqualsIsNumber(boolean expect, String text) {
+        assertEquals(expect, NumberBuilder.isNumber(text), text);
+        assertEquals(expect, NumberBuilder.isNumber(text, false), text);
 
         assertEquals(expect, NumberBuilder.isNumber(
-            PREFIX + s + SUFFIX,
+            PREFIX + text + SUFFIX,
             PREFIX.length(),
-            PREFIX.length() + s.length()),
-            s);
+            PREFIX.length() + text.length()),
+            text);
 
-        assertEquals(expect, new NumberBuilder(s).isNumber(), s);
+        assertEquals(expect, new NumberBuilder(text).isNumber(), text);
 
         assertEquals(expect, new NumberBuilder(
-            PREFIX + s + SUFFIX,
+            PREFIX + text + SUFFIX,
             PREFIX.length(),
-            PREFIX.length() + s.length()).isNumber(),
-            s);
+            PREFIX.length() + text.length()).isNumber(),
+            text);
 
-        assertEquals(expect, new NumberBuilder(s).hasIntegerPart(), s);
+        assertEquals(expect, new NumberBuilder(text).hasIntegerPart(), text);
     }
 
-    private void assertEquals_isInteger(boolean expect, String s) {
-        assertEquals(expect, NumberBuilder.isNonFractional(s), s);
-        assertEquals(expect, NumberBuilder.isNumber(s, true), s);
+    private void assertEqualsIsInteger(boolean expect, String text) {
+        assertEquals(expect, NumberBuilder.isNonFractional(text), text);
+        assertEquals(expect, NumberBuilder.isNumber(text, true), text);
 
         assertEquals(expect, NumberBuilder.isNonFractional(
-            PREFIX + s + SUFFIX,
+            PREFIX + text + SUFFIX,
             PREFIX.length(),
-            PREFIX.length() + s.length()),
-            s);
+            PREFIX.length() + text.length()),
+            text);
         
-        assertEquals(expect, new NumberBuilder(s).isNonFractional(), s);
+        assertEquals(expect, new NumberBuilder(text).isNonFractional(), text);
 
         assertEquals(expect, new NumberBuilder(
-            PREFIX + s + SUFFIX,
+            PREFIX + text + SUFFIX,
             PREFIX.length(),
-            PREFIX.length() + s.length()).isNonFractional(),
-            s);
+            PREFIX.length() + text.length()).isNonFractional(),
+            text);
     }
 
-    private void assertToString(String s) {
-        NumberBuilder nb = newNumberBuilder(s);
-        assertArrayEquals(nb.toChars(), NumberBuilder.toChars(nb), s);
-        assertEquals(nb.toString(), NumberBuilder.toString(nb), s);
+    private void assertToString(String text) {
+        NumberBuilder numb = newNumberBuilder(text);
+
+        assertArrayEquals(
+                numb.toChars(),
+                NumberBuilder.toChars(numb),
+                text);
+
+        assertEquals(
+                numb.toString(),
+                NumberBuilder.toString(numb),
+                text);
     }
     
     @ParameterizedTest
@@ -126,19 +134,19 @@ class NumberBuilderTest {
     @CsvSource({
         Math.PI + ", 3.141593"
     })
-    void testBigDecimal(double in, double expect) {
+    void testBigDecimal(double actual, double expect) {
         final BigMathProvider mcp = new BigMath(
             MathContext.DECIMAL32,
             null,
             null,
             null);
 
-        final String sin = String.valueOf(in);
-        NumberBuilder nb = newNumberBuilder(sin);
-        nb.setBigMathProvider(mcp);
-        assertEquals(mcp, nb.getBigMathProvider(), sin);
-        BigDecimal bd = nb.toBigDecimal();
-        assertEquals(expect, bd.doubleValue(), String.valueOf(in));
+        final String sin = String.valueOf(actual);
+        NumberBuilder numb = newNumberBuilder(sin);
+        numb.setBigMathProvider(mcp);
+        assertEquals(mcp, numb.getBigMathProvider(), sin);
+        BigDecimal dec = numb.toBigDecimal();
+        assertEquals(expect, dec.doubleValue(), String.valueOf(actual));
     }
 
     @ParameterizedTest
@@ -147,38 +155,45 @@ class NumberBuilderTest {
     @ValueSource(longs = {
         0, -0,
         1, -1,
-        123456, -123456,
-        12345678905432132L,
+        123_456, -123_456,
+        12_345_678_905_432_132L,
         Long.MAX_VALUE,
         Long.MAX_VALUE - 1,
         Long.MIN_VALUE,
         Long.MIN_VALUE - 1,
     })
-    void testLong(long g) {
+    void testLong(long expected) {
         assertEquals(
-                Long.valueOf(g),
-                newNumberBuilder(String.valueOf(g)).build(true),
-                String.valueOf(g));
+                Long.valueOf(expected),
+                newNumberBuilder(String.valueOf(expected)).build(true),
+                String.valueOf(expected));
 
-        assertEquals_isNumber(true, String.valueOf(g));
-        assertEquals_isInteger(true, String.valueOf(g));
-        assertToString(String.valueOf(g));
+        assertEqualsIsNumber(true, String.valueOf(expected));
+        assertEqualsIsInteger(true, String.valueOf(expected));
+        assertToString(String.valueOf(expected));
     }
 
     @ParameterizedTest
     @Tag(TAG_LONG)
     @Tag(TAG_NUMBER)
     @ValueSource(strings = {
-        "0", "-0",
-        "1", "-1",
-        "123456", "-123456",
+        "0",
+        "-0",
+        "1",
+        "-1",
+        "123456",
+        "-123456",
         "12345678905432132",
     })
-    void testLong(String s) {
-        assertEquals(Long.valueOf(s), newNumberBuilder(s).build(true), s);
-        assertEquals_isNumber(true, s);
-        assertEquals_isInteger(true, s);
-        assertToString(s);
+    void testLong(String text) {
+        assertEquals(
+                Long.valueOf(text),
+                newNumberBuilder(text).build(true),
+                text);
+
+        assertEqualsIsNumber(true, text);
+        assertEqualsIsInteger(true, text);
+        assertToString(text);
     }
     
     @ParameterizedTest
@@ -195,11 +210,15 @@ class NumberBuilderTest {
         "'-2e+1',-20",
         "'4e+15',4000000000000000",
     })
-    void testLong(String in, long out) {
-        assertEquals(Long.valueOf(out), newNumberBuilder(in).build(true), in);
-        assertEquals_isNumber(true, in);
-        assertEquals_isInteger(true, in);
-        assertToString(in);
+    void testLong(String text, long expected) {
+        assertEquals(
+                Long.valueOf(expected),
+                newNumberBuilder(text).build(true),
+                text);
+
+        assertEqualsIsNumber(true, text);
+        assertEqualsIsInteger(true, text);
+        assertToString(text);
     }
     
     @ParameterizedTest
@@ -220,48 +239,48 @@ class NumberBuilderTest {
         
         "123456789012345678901"
     })
-    void testDouble(String s) {
+    void testDouble(String text) {
         assertEquals(
-                Double.valueOf(s),
-                newNumberBuilder(s).build(true),
-                s);
+                Double.valueOf(text),
+                newNumberBuilder(text).build(true),
+                text);
 
         assertEquals(
-            Double.valueOf(s),
-            newNumberBuilder(s).toDouble(),
-            s);
+            Double.valueOf(text),
+            newNumberBuilder(text).toDouble(),
+            text);
         
         assertEquals(
-            new BigDecimal(s),
-            newNumberBuilder(s).toBigDecimal(),
-            s);
+            new BigDecimal(text),
+            newNumberBuilder(text).toBigDecimal(),
+            text);
 
-        assertEquals_isNumber(true, s);
+        assertEqualsIsNumber(true, text);
 
-        assertEquals_isInteger(
-            s.indexOf('.') == -1 && s.indexOf('e') == -1,
-            s);
+        assertEqualsIsInteger(
+            text.indexOf('.') == -1 && text.indexOf('e') == -1,
+            text);
         
-        assertEquals(s.indexOf('.') != -1,
-            new NumberBuilder(s).hasFractionalPart(),
-            s);
+        assertEquals(text.indexOf('.') != -1,
+            new NumberBuilder(text).hasFractionalPart(),
+            text);
 
-        assertToString(s);
+        assertToString(text);
     }
     
     @ParameterizedTest
     @Tag(TAG_DOUBLE)
     @Tag(TAG_NUMBER)
     @MethodSource("integerAsDoubleProvider")
-    void testDouble(double g) {
-        String asString = String.format("%.0f", g);
+    void testDouble(double value) {
+        String asString = String.format("%.0f", value);
         assertEquals(
-                Double.valueOf(g),
+                Double.valueOf(value),
                 newNumberBuilder(asString).build(true),
                 asString);
 
-        assertEquals_isNumber(true, asString);
-        assertEquals_isInteger(true, asString);
+        assertEqualsIsNumber(true, asString);
+        assertEqualsIsInteger(true, asString);
         assertToString(asString);
     }
     
@@ -278,20 +297,20 @@ class NumberBuilderTest {
         Long.MAX_VALUE + "e2," + Long.MAX_VALUE + "00",
         Long.MIN_VALUE + "e3," + Long.MIN_VALUE + "000",
     })
-    void testBigInteger(String in, String out) {
-        out = out == null ? in : out;
+    void testBigInteger(String text, String expected) {
+        String expectedText = expected == null ? text : expected;
 
         assertEquals(
-                new BigInteger(out),
-                newNumberBuilder(String.valueOf(in)).build(false),
-                in);
+                new BigInteger(expectedText),
+                newNumberBuilder(String.valueOf(text)).build(false),
+                text);
 
-        assertEquals_isNumber(true, in);
-        assertEquals_isInteger(true, in);
-        assertEquals_isNumber(true, out);
-        assertEquals_isInteger(true, out);
-        assertToString(in);
-        assertToString(out);
+        assertEqualsIsNumber(true, text);
+        assertEqualsIsInteger(true, text);
+        assertEqualsIsNumber(true, expectedText);
+        assertEqualsIsInteger(true, expectedText);
+        assertToString(text);
+        assertToString(expectedText);
     }
 
     @ParameterizedTest
@@ -303,8 +322,8 @@ class NumberBuilderTest {
     })
     void testNonNumberLiterals(String text) {
         assertFalse(JsonUrl.parseLiteral(text) instanceof Number, text);
-        assertEquals_isNumber(false, text);
-        assertEquals_isInteger(false, text);
+        assertEqualsIsNumber(false, text);
+        assertEqualsIsInteger(false, text);
     }
     
     @ParameterizedTest
@@ -332,8 +351,8 @@ class NumberBuilderTest {
     }
 
     @Test
-    void testEmptyString() {
-        NumberText text = new NumberText() { // NOPMD
+    void testEmptyString() { // NOPMD - CyclomaticComplexity
+        NumberText text = new NumberText() { // NOPMD - DataflowAnomalyAnalysis
 
             @Override
             public CharSequence getText() {

--- a/module/jsonurl-core/src/test/java/org/jsonurl/ValueTypeTest.java
+++ b/module/jsonurl-core/src/test/java/org/jsonurl/ValueTypeTest.java
@@ -1,5 +1,3 @@
-package org.jsonurl;
-
 /*
  * Copyright 2019 David MacCormack
  * 
@@ -17,6 +15,8 @@ package org.jsonurl;
  * under the License.
  */
 
+package org.jsonurl;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.junit.jupiter.params.ParameterizedTest;
@@ -29,25 +29,25 @@ class ValueTypeTest {
 
     @ParameterizedTest
     @EnumSource(ValueType.class)
-    void test(ValueType t) {
+    void test(ValueType type) {
         assertEquals(
-            t == ValueType.ARRAY || t == ValueType.OBJECT,
-            t.isComposite(),
-            t.name());
+            type == ValueType.ARRAY || type == ValueType.OBJECT,
+            type.isComposite(),
+            type.name());
         
         assertEquals(
-            t == ValueType.ARRAY || t == ValueType.OBJECT || t == ValueType.NULL,
-            t.isCompositeOrNull(),
-            t.name());
+            type == ValueType.ARRAY || type == ValueType.OBJECT || type == ValueType.NULL,
+            type.isCompositeOrNull(),
+            type.name());
         
         assertEquals(
-            t != ValueType.ARRAY && t != ValueType.OBJECT && t != ValueType.NULL,
-            t.isPrimitive(),
-            t.name());
+            type != ValueType.ARRAY && type != ValueType.OBJECT && type != ValueType.NULL,
+            type.isPrimitive(),
+            type.name());
         
         assertEquals(
-            t != ValueType.ARRAY && t != ValueType.OBJECT,
-            t.isPrimitiveOrNull(),
-            t.name());
+            type != ValueType.ARRAY && type != ValueType.OBJECT,
+            type.isPrimitiveOrNull(),
+            type.name());
     }
 }

--- a/module/jsonurl-core/src/test/java/org/jsonurl/j2se/AbstractJavaValueFactoryParseTest.java
+++ b/module/jsonurl-core/src/test/java/org/jsonurl/j2se/AbstractJavaValueFactoryParseTest.java
@@ -37,7 +37,7 @@ import org.junit.jupiter.api.Test;
  * @author David MacCormack
  * @since 2019-09-01
  */
-abstract class JavaValueFactoryParseTest extends AbstractParseTest<
+abstract class AbstractJavaValueFactoryParseTest extends AbstractParseTest<
         Object,
         Object,
         List<Object>,
@@ -52,7 +52,7 @@ abstract class JavaValueFactoryParseTest extends AbstractParseTest<
     /**
      * Create a new JavaValueFactoryParseTest.
      */
-    public JavaValueFactoryParseTest(JavaValueFactory factory) {
+    public AbstractJavaValueFactoryParseTest(JavaValueFactory factory) {
         super(factory);
     }
 
@@ -161,10 +161,15 @@ abstract class JavaValueFactoryParseTest extends AbstractParseTest<
     
     @Override
     protected JavaValueFactory newBigMathFactory(
-                MathContext mc,
+                MathContext mctxt,
                 String boundNeg,
                 String boundPos,
                 BigIntegerOverflow over) {
-        return new JavaValueFactory.BigMathFactory(mc, boundNeg, boundPos, over);
+
+        return new JavaValueFactory.BigMathFactory(
+                mctxt,
+                boundNeg,
+                boundPos,
+                over);
     }
 }

--- a/module/jsonurl-core/src/test/java/org/jsonurl/j2se/AbstractJavaValueWriteTest.java
+++ b/module/jsonurl-core/src/test/java/org/jsonurl/j2se/AbstractJavaValueWriteTest.java
@@ -32,19 +32,20 @@ import org.junit.jupiter.api.Nested;
  * @author David MacCormack
  * @since 2020-09-01
  */
-public abstract class JavaValueWriteTest extends AbstractJsonTextBuilderTest<
-    Object,
-    Object,
-    List<Object>,
-    List<Object>,
-    Map<String,Object>,
-    Map<String,Object>> {
+public abstract class AbstractJavaValueWriteTest
+        extends AbstractJsonTextBuilderTest<
+            Object,
+            Object,
+            List<Object>,
+            List<Object>,
+            Map<String,Object>,
+            Map<String,Object>> {
 
     /**
      * JavaValueFactory.PRIMITIVE JavaValueWriteTest.
      */
     @Nested
-    static class PrimitiveWriteTest extends JavaValueWriteTest {
+    static class PrimitiveWriteTest extends AbstractJavaValueWriteTest {
 
         @Override
         public ValueFactory<
@@ -64,7 +65,7 @@ public abstract class JavaValueWriteTest extends AbstractJsonTextBuilderTest<
      * JavaValueFactory.DOUBLE JavaValueWriteTest.
      */
     @Nested
-    static class DoubleWriteTest extends JavaValueWriteTest {
+    static class DoubleWriteTest extends AbstractJavaValueWriteTest {
 
         @Override
         public ValueFactory<
@@ -83,7 +84,7 @@ public abstract class JavaValueWriteTest extends AbstractJsonTextBuilderTest<
      * JavaValueFactory.BIGMATH32 JavaValueWriteTest.
      */
     @Nested
-    static class BigMathWriteTest extends JavaValueWriteTest {
+    static class BigMathWriteTest extends AbstractJavaValueWriteTest {
 
         @Override
         public ValueFactory<
@@ -102,7 +103,7 @@ public abstract class JavaValueWriteTest extends AbstractJsonTextBuilderTest<
      * JavaValueFactory.BIGMATH32 JavaValueWriteTest.
      */
     @Nested
-    static class BigMathWriteTest32 extends JavaValueWriteTest {
+    static class BigMathWriteTest32 extends AbstractJavaValueWriteTest {
 
         @Override
         public ValueFactory<
@@ -121,7 +122,7 @@ public abstract class JavaValueWriteTest extends AbstractJsonTextBuilderTest<
      * JavaValueFactory.BIGMATH64 JavaValueWriteTest.
      */
     @Nested
-    static class BigMathWriteTest64 extends JavaValueWriteTest {
+    static class BigMathWriteTest64 extends AbstractJavaValueWriteTest {
 
         @Override
         public ValueFactory<
@@ -140,7 +141,7 @@ public abstract class JavaValueWriteTest extends AbstractJsonTextBuilderTest<
      * JavaValueFactory.BIGMATH128 JavaValueWriteTest.
      */
     @Nested
-    static class BigMathWriteTest128 extends JavaValueWriteTest {
+    static class BigMathWriteTest128 extends AbstractJavaValueWriteTest {
 
         @Override
         public ValueFactory<
@@ -156,7 +157,10 @@ public abstract class JavaValueWriteTest extends AbstractJsonTextBuilderTest<
     }
 
     @Override
-    public void write(JsonTextBuilder<?, ?> out, Object value) throws IOException {
-        JsonUrlWriter.write(out, value);
+    public void write(
+            JsonTextBuilder<?, ?> dest,
+            Object value) throws IOException {
+
+        JsonUrlWriter.write(dest, value);
     }
 }

--- a/module/jsonurl-core/src/test/java/org/jsonurl/j2se/BigMathParseTest.java
+++ b/module/jsonurl-core/src/test/java/org/jsonurl/j2se/BigMathParseTest.java
@@ -24,12 +24,12 @@ package org.jsonurl.j2se;
  * @author David MacCormack
  * @since 2019-09-01
  */
-class BigMathParseTest extends JavaValueFactoryParseTest {
+class BigMathParseTest extends AbstractJavaValueFactoryParseTest {
 
     /**
      * Unit test using JavaValueFactory.BIGMATH32.
      */
-    static final class Test32 extends JavaValueFactoryParseTest {
+    static final class Test32 extends AbstractJavaValueFactoryParseTest {
         /**
          * Create a new Test32.
          */
@@ -41,7 +41,7 @@ class BigMathParseTest extends JavaValueFactoryParseTest {
     /**
      * Unit test using JavaValueFactory.BIGMATH64.
      */
-    static final class Test64 extends JavaValueFactoryParseTest {
+    static final class Test64 extends AbstractJavaValueFactoryParseTest {
         /**
          * Create a new Test64.
          */
@@ -53,7 +53,7 @@ class BigMathParseTest extends JavaValueFactoryParseTest {
     /**
      * Unit test using JavaValueFactory.BIGMATH128.
      */
-    static final class Test128 extends JavaValueFactoryParseTest {
+    static final class Test128 extends AbstractJavaValueFactoryParseTest {
         /**
          * Create a new Test128.
          */

--- a/module/jsonurl-core/src/test/java/org/jsonurl/j2se/DoubleParseTest.java
+++ b/module/jsonurl-core/src/test/java/org/jsonurl/j2se/DoubleParseTest.java
@@ -1,5 +1,3 @@
-package org.jsonurl.j2se;
-
 /*
  * Copyright 2019 David MacCormack
  * 
@@ -17,6 +15,8 @@ package org.jsonurl.j2se;
  * under the License.
  */
 
+package org.jsonurl.j2se;
+
 /**
  * Unit test using JavaValueFactory.DOUBLE
  *
@@ -24,7 +24,7 @@ package org.jsonurl.j2se;
  * @author David MacCormack
  * @since 2019-09-01
  */
-public class DoubleParseTest extends JavaValueFactoryParseTest {
+public class DoubleParseTest extends AbstractJavaValueFactoryParseTest {
 
     /**
      * Create a new DoubleParseTest.

--- a/module/jsonurl-core/src/test/java/org/jsonurl/j2se/JavaValueWriteStaticTest.java
+++ b/module/jsonurl-core/src/test/java/org/jsonurl/j2se/JavaValueWriteStaticTest.java
@@ -241,7 +241,6 @@ class JavaValueWriteStaticTest {
             () -> JsonUrlWriter.write(new JsonUrlStringBuilder(), newNonStringMap()));
     }
     
-    @SuppressWarnings("PMD.UseConcurrentHashMap")
     private Map<?,?> newNonStringMap() {
         Map<Object, Object> ret = new HashMap<>(); 
         ret.put(new Object(), new Object());

--- a/module/jsonurl-core/src/test/java/org/jsonurl/j2se/ParserTest.java
+++ b/module/jsonurl-core/src/test/java/org/jsonurl/j2se/ParserTest.java
@@ -50,22 +50,22 @@ class ParserTest {
 
     @Test
     void testMaxParseChars() {
-        Parser p = new Parser();
-        p.setMaxParseChars(13);
-        assertEquals(13, p.getMaxParseChars(), "getMaxParseChars");
+        Parser par = new Parser();
+        par.setMaxParseChars(13);
+        assertEquals(13, par.getMaxParseChars(), "getMaxParseChars");
     }
 
     @Test
     void testMaxParseDepth() {
-        Parser p = new Parser();
-        p.setMaxParseDepth(13);
-        assertEquals(13, p.getMaxParseDepth(), "getMaxParseDepth");
+        Parser par = new Parser();
+        par.setMaxParseDepth(13);
+        assertEquals(13, par.getMaxParseDepth(), "getMaxParseDepth");
     }
 
     @Test
     void testMaxParseValues() {
-        Parser p = new Parser();
-        p.setMaxParseValues(13);
-        assertEquals(13, p.getMaxParseValues(), "getMaxParseValues");
+        Parser par = new Parser();
+        par.setMaxParseValues(13);
+        assertEquals(13, par.getMaxParseValues(), "getMaxParseValues");
     }
 }

--- a/module/jsonurl-core/src/test/java/org/jsonurl/j2se/PrimitiveParseTest.java
+++ b/module/jsonurl-core/src/test/java/org/jsonurl/j2se/PrimitiveParseTest.java
@@ -24,7 +24,7 @@ package org.jsonurl.j2se;
  * @author David MacCormack
  * @since 2019-09-01
  */
-public class PrimitiveParseTest extends JavaValueFactoryParseTest {
+public class PrimitiveParseTest extends AbstractJavaValueFactoryParseTest {
 
     /**
      * Create a new PrimitiveParseTest.

--- a/module/jsonurl-jsonorg/src/main/java/org/jsonurl/jsonorg/JsonOrgValueFactory.java
+++ b/module/jsonurl-jsonorg/src/main/java/org/jsonurl/jsonorg/JsonOrgValueFactory.java
@@ -1,5 +1,3 @@
-package org.jsonurl.jsonorg;
-
 /*
  * Copyright 2019 David MacCormack
  * 
@@ -16,6 +14,8 @@ package org.jsonurl.jsonorg;
  * specific language governing permissions and limitations
  * under the License.
  */
+
+package org.jsonurl.jsonorg;
 
 import java.math.MathContext;
 import java.util.Set;
@@ -44,7 +44,40 @@ public interface JsonOrgValueFactory extends ValueFactory.TransparentBuilder<
         Number,
         Object,
         String> {
+
+
+    /**
+     * This represents the empty composite value.
+     */
+    Object EMPTY = new JSONObject();
+
+    /**
+     * A singleton instance of {@link BigMathFactory} with 32-bit boundaries.
+     */
+    BigMathFactory BIGMATH32 = new BigMathFactory(
+        MathContext.DECIMAL32,
+        BigMath.BIG_INTEGER32_BOUNDARY_NEG,
+        BigMath.BIG_INTEGER32_BOUNDARY_POS,
+        null);
     
+    /**
+     * A singleton instance of {@link BigMathFactory} with 64-bit boundaries.
+     */
+    BigMathFactory BIGMATH64 = new BigMathFactory(
+        MathContext.DECIMAL64,
+        BigMath.BIG_INTEGER64_BOUNDARY_NEG,
+        BigMath.BIG_INTEGER64_BOUNDARY_POS,
+        null);
+    
+    /**
+     * A singleton instance of {@link BigMathFactory} with 128-bit boundaries.
+     */
+    BigMathFactory BIGMATH128 = new BigMathFactory(
+        MathContext.DECIMAL128,
+        BigMath.BIG_INTEGER128_BOUNDARY_NEG,
+        BigMath.BIG_INTEGER128_BOUNDARY_POS,
+        null);
+
     /**
      * A {@link JsonOrgValueFactory} that uses
      * {@link java.math.BigInteger BigInteger} and
@@ -56,7 +89,7 @@ public interface JsonOrgValueFactory extends ValueFactory.TransparentBuilder<
      * parts that are too big to stored in a {@link java.lang.Double Double}
      * will be stored in a {@link java.math.BigDecimal BigDecimal}.
      */
-    public static class BigMathFactory extends BigMath
+    class BigMathFactory extends BigMath
             implements JsonOrgValueFactory, ValueFactory.BigMathFactory<
                 Object,
                 Object,
@@ -70,18 +103,18 @@ public interface JsonOrgValueFactory extends ValueFactory.TransparentBuilder<
                 String> {
         /**
          * Create a new BigMathFactory JsonOrgValueFactory using the given MathContext.
-         * @param mc a valid MathContext or null
+         * @param mctxt a valid MathContext or null
          * @param bigIntegerBoundaryNeg negative value boundary
          * @param bigIntegerBoundaryPos positive value boundary
          * @param bigIntegerOverflow action on boundary overflow
          */
         public BigMathFactory(
-            MathContext mc,
+            MathContext mctxt,
             String bigIntegerBoundaryNeg,
             String bigIntegerBoundaryPos,
             BigIntegerOverflow bigIntegerOverflow) {
 
-            super(mc,
+            super(mctxt,
                 bigIntegerBoundaryNeg,
                 bigIntegerBoundaryPos,
                 bigIntegerOverflow);
@@ -92,11 +125,6 @@ public interface JsonOrgValueFactory extends ValueFactory.TransparentBuilder<
             return NumberBuilder.build(text, false, this);
         }
     }
-
-    /**
-     * This represents the empty composite value.
-     */
-    public static final Object EMPTY = new JSONObject();
     
     /**
      * A singleton instance of {@link JsonOrgValueFactory}.
@@ -106,7 +134,7 @@ public interface JsonOrgValueFactory extends ValueFactory.TransparentBuilder<
      * NumberBuilder.build(text,true)}
      * to parse JSON&#x2192;URL numbers.  
      */
-    public static final JsonOrgValueFactory PRIMITIVE = new JsonOrgValueFactory() {
+    JsonOrgValueFactory PRIMITIVE = new JsonOrgValueFactory() {
 
         @Override
         public Number getNumber(NumberText text) {
@@ -121,40 +149,13 @@ public interface JsonOrgValueFactory extends ValueFactory.TransparentBuilder<
      * {@link java.lang.Double#valueOf(String) Double.valueOf(text)}
      * to parse JSON&#x2192;URL numbers.
      */
-    public static final JsonOrgValueFactory DOUBLE = new JsonOrgValueFactory() {
+    JsonOrgValueFactory DOUBLE = new JsonOrgValueFactory() {
 
         @Override
         public Number getNumber(NumberText text) {
             return Double.valueOf(text.toString());
         }
     };
-    
-    /**
-     * A singleton instance of {@link BigMathFactory} with 32-bit boundaries.
-     */
-    public static final BigMathFactory BIGMATH32 = new BigMathFactory(
-        MathContext.DECIMAL32,
-        BigMath.BIG_INTEGER32_BOUNDARY_NEG,
-        BigMath.BIG_INTEGER32_BOUNDARY_POS,
-        null);
-    
-    /**
-     * A singleton instance of {@link BigMathFactory} with 64-bit boundaries.
-     */
-    public static final BigMathFactory BIGMATH64 = new BigMathFactory(
-        MathContext.DECIMAL64,
-        BigMath.BIG_INTEGER64_BOUNDARY_NEG,
-        BigMath.BIG_INTEGER64_BOUNDARY_POS,
-        null);
-    
-    /**
-     * A singleton instance of {@link BigMathFactory} with 128-bit boundaries.
-     */
-    public static final BigMathFactory BIGMATH128 = new BigMathFactory(
-        MathContext.DECIMAL128,
-        BigMath.BIG_INTEGER128_BOUNDARY_NEG,
-        BigMath.BIG_INTEGER128_BOUNDARY_POS,
-        null);
 
     @Override
     default JSONArray newArrayBuilder() {
@@ -197,8 +198,8 @@ public interface JsonOrgValueFactory extends ValueFactory.TransparentBuilder<
     }
 
     @Override
-    default String getString(CharSequence s, int start, int stop) {
-        return JavaValueFactory.toJavaString(s, start, stop);
+    default String getString(CharSequence text, int start, int stop) {
+        return JavaValueFactory.toJavaString(text, start, stop);
     }
     
     @Override

--- a/module/jsonurl-jsonorg/src/main/java/org/jsonurl/jsonorg/package-info.java
+++ b/module/jsonurl-jsonorg/src/main/java/org/jsonurl/jsonorg/package-info.java
@@ -1,3 +1,21 @@
+
+/*
+ * Copyright 2019 David MacCormack
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 /**
  * An implementation of the JSON&#x2192;URL interface based on Douglas
  * Crockford's original Java implementation of JSON.
@@ -19,20 +37,3 @@
  * @see <a href="https://mvnrepository.com/artifact/org.json/json">Maven</a>
  */
 package org.jsonurl.jsonorg;
-
-/*
- * Copyright 2019 David MacCormack
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not
- * use this file except in compliance with the License. You may obtain a copy
- * of the License at
- *
- *  http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
- */

--- a/module/jsonurl-jsonorg/src/test/java/org/jsonurl/jsonorg/AbstractJsonOrgParseTest.java
+++ b/module/jsonurl-jsonorg/src/test/java/org/jsonurl/jsonorg/AbstractJsonOrgParseTest.java
@@ -1,5 +1,3 @@
-package org.jsonurl.jsonorg;
-
 /*
  * Copyright 2019 David MacCormack
  * 
@@ -16,6 +14,8 @@ package org.jsonurl.jsonorg;
  * specific language governing permissions and limitations
  * under the License.
  */
+
+package org.jsonurl.jsonorg;
 
 import java.math.MathContext;
 import java.util.Objects;
@@ -35,7 +35,7 @@ import org.jsonurl.ValueFactory;
  * @author David MacCormack
  * @since 2019-09-01
  */
-abstract class JsonOrgParseTest extends AbstractParseTest<
+abstract class AbstractJsonOrgParseTest extends AbstractParseTest<
     Object,
     Object,
     JSONArray,
@@ -50,7 +50,7 @@ abstract class JsonOrgParseTest extends AbstractParseTest<
     /**
      * Create a new JsonOrgParseTest.
      */
-    public JsonOrgParseTest(JsonOrgValueFactory factory) {
+    public AbstractJsonOrgParseTest(JsonOrgValueFactory factory) {
         super(factory);
     }
     
@@ -143,17 +143,17 @@ abstract class JsonOrgParseTest extends AbstractParseTest<
             Number,
             Object,
             String> newBigMathFactory(
-                MathContext mc,
+                MathContext mctxt,
                 String boundNeg,
                 String boundPos,
                 BigIntegerOverflow over) {
 
         return new JsonOrgValueFactory.BigMathFactory(
-            mc, boundNeg, boundPos, over);
+            mctxt, boundNeg, boundPos, over);
     }
 
     @Override
-    protected boolean isEqual(Object a, Object b) {
+    protected boolean isEqual(Object a, Object b) { // NOPMD - ShortVariable
         if (a == null) {
             return b == null;
         }
@@ -163,11 +163,13 @@ abstract class JsonOrgParseTest extends AbstractParseTest<
         }
 
         if (a instanceof JSONArray) {
-            return ((JSONArray)a).toList().equals(((JSONArray)b).toList());
+            return b instanceof JSONArray
+                && ((JSONArray)a).toList().equals(((JSONArray)b).toList());
         }
 
         if (a instanceof JSONObject) {
-            return ((JSONObject)a).toMap().equals(((JSONObject)b).toMap());
+            return b instanceof JSONObject
+                && ((JSONObject)a).toMap().equals(((JSONObject)b).toMap());
         }
 
         return Objects.equals(a, b);

--- a/module/jsonurl-jsonorg/src/test/java/org/jsonurl/jsonorg/BigMathParseTest.java
+++ b/module/jsonurl-jsonorg/src/test/java/org/jsonurl/jsonorg/BigMathParseTest.java
@@ -1,5 +1,3 @@
-package org.jsonurl.jsonorg;
-
 /*
  * Copyright 2019 David MacCormack
  * 
@@ -17,6 +15,8 @@ package org.jsonurl.jsonorg;
  * under the License.
  */
 
+package org.jsonurl.jsonorg;
+
 /**
  * Unit test using JsonOrgValueFactory.BigMathFactory.
  *
@@ -24,12 +24,12 @@ package org.jsonurl.jsonorg;
  * @author David MacCormack
  * @since 2019-09-01
  */
-class BigMathParseTest extends JsonOrgParseTest {
+class BigMathParseTest extends AbstractJsonOrgParseTest {
     
     /**
      * Unit test using JsonOrgValueFactory.BIGMATH32.
      */
-    static final class Test32 extends JsonOrgParseTest {
+    static final class Test32 extends AbstractJsonOrgParseTest {
         /**
          * Create a new Test32.
          */
@@ -41,7 +41,7 @@ class BigMathParseTest extends JsonOrgParseTest {
     /**
      * Unit test using JsonOrgValueFactory.BIGMATH64.
      */
-    static final class Test64 extends JsonOrgParseTest {
+    static final class Test64 extends AbstractJsonOrgParseTest {
         /**
          * Create a new Test64.
          */
@@ -53,7 +53,7 @@ class BigMathParseTest extends JsonOrgParseTest {
     /**
      * Unit test using JsonOrgValueFactory.BIGMATH128.
      */
-    static final class Test128 extends JsonOrgParseTest {
+    static final class Test128 extends AbstractJsonOrgParseTest {
         /**
          * Create a new Test128.
          */

--- a/module/jsonurl-jsonorg/src/test/java/org/jsonurl/jsonorg/DoubleParseTest.java
+++ b/module/jsonurl-jsonorg/src/test/java/org/jsonurl/jsonorg/DoubleParseTest.java
@@ -1,5 +1,3 @@
-package org.jsonurl.jsonorg;
-
 /*
  * Copyright 2019 David MacCormack
  * 
@@ -17,6 +15,8 @@ package org.jsonurl.jsonorg;
  * under the License.
  */
 
+package org.jsonurl.jsonorg;
+
 /**
  * Unit test using JsonOrgValueFactory.DOUBLE
  *
@@ -24,7 +24,7 @@ package org.jsonurl.jsonorg;
  * @author David MacCormack
  * @since 2019-09-01
  */
-public class DoubleParseTest extends JsonOrgParseTest {
+public class DoubleParseTest extends AbstractJsonOrgParseTest {
 
     /**
      * Create a new DoubleParseTest.

--- a/module/jsonurl-jsonorg/src/test/java/org/jsonurl/jsonorg/JsonOrgWriteTest.java
+++ b/module/jsonurl-jsonorg/src/test/java/org/jsonurl/jsonorg/JsonOrgWriteTest.java
@@ -17,6 +17,7 @@
 
 package org.jsonurl.jsonorg;
 
+import java.io.IOException;
 import org.json.JSONArray;
 import org.json.JSONObject;
 import org.json.JSONWriter;
@@ -38,18 +39,19 @@ public class JsonOrgWriteTest extends AbstractJsonApiWriteTest<
         JSONObject> {
 
     @Override
-    public void write(JsonTextBuilder<?, ?> out, Object value) throws Exception {
-        JsonUrlWriter.write(out, value);
+    public void write(JsonTextBuilder<?, ?> dest, Object value)
+            throws IOException {
+        JsonUrlWriter.write(dest, value);
     }
 
     @Override
-    public JSONArray newArray(String s) {
-        return new JSONArray(s);
+    public JSONArray newArray(String text) {
+        return new JSONArray(text);
     }
 
     @Override
-    public JSONObject newObject(String s) {
-        return new JSONObject(s);
+    public JSONObject newObject(String text) {
+        return new JSONObject(text);
     }
 
     @Override

--- a/module/jsonurl-jsonorg/src/test/java/org/jsonurl/jsonorg/PrimitiveParseTest.java
+++ b/module/jsonurl-jsonorg/src/test/java/org/jsonurl/jsonorg/PrimitiveParseTest.java
@@ -1,5 +1,3 @@
-package org.jsonurl.jsonorg;
-
 /*
  * Copyright 2019 David MacCormack
  * 
@@ -17,6 +15,8 @@ package org.jsonurl.jsonorg;
  * under the License.
  */
 
+package org.jsonurl.jsonorg;
+
 /**
  * Unit test using JsonOrgValueFactory.PRIMITIVE
  *
@@ -24,7 +24,7 @@ package org.jsonurl.jsonorg;
  * @author David MacCormack
  * @since 2019-09-01
  */
-public class PrimitiveParseTest extends JsonOrgParseTest {
+public class PrimitiveParseTest extends AbstractJsonOrgParseTest {
 
     /**
      * Create a new PrimitiveParseTest.

--- a/module/jsonurl-jsr374/src/test/java/org/jsonurl/jsonp/AbstractJsonpParseTest.java
+++ b/module/jsonurl-jsr374/src/test/java/org/jsonurl/jsonp/AbstractJsonpParseTest.java
@@ -41,7 +41,7 @@ import org.jsonurl.ValueFactory;
  * @author David MacCormack
  * @since 2019-09-01
  */
-abstract class JsonpParseTest extends AbstractParseTest<
+abstract class AbstractJsonpParseTest extends AbstractParseTest<
         JsonValue,
         JsonStructure,
         JsonArrayBuilder,
@@ -56,7 +56,7 @@ abstract class JsonpParseTest extends AbstractParseTest<
     /**
      * Create a new JsonpParseTest.
      */
-    public JsonpParseTest(JsonpValueFactory factory) {
+    public AbstractJsonpParseTest(JsonpValueFactory factory) {
         super(factory);
     }
     
@@ -153,12 +153,12 @@ abstract class JsonpParseTest extends AbstractParseTest<
             JsonNumber,
             JsonValue,
             JsonString> newBigMathFactory(
-                MathContext mc,
+                MathContext mctxt,
                 String boundNeg,
                 String boundPos,
                 BigIntegerOverflow over) {
         return new JsonpValueFactory.BigMathFactory(
-            mc, boundNeg, boundPos, over);
+            mctxt, boundNeg, boundPos, over);
     }
 
     @Override

--- a/module/jsonurl-jsr374/src/test/java/org/jsonurl/jsonp/BigMathParseTest.java
+++ b/module/jsonurl-jsr374/src/test/java/org/jsonurl/jsonp/BigMathParseTest.java
@@ -27,12 +27,12 @@ import org.jsonurl.BigMathProvider;
  * @author David MacCormack
  * @since 2019-09-01
  */
-class BigMathParseTest extends JsonpParseTest {
+class BigMathParseTest extends AbstractJsonpParseTest {
 
     /**
      * Unit test using JsonpValueFactory.BIGMATH32.
      */
-    static final class Math32 extends JsonpParseTest {
+    static final class Math32 extends AbstractJsonpParseTest {
 
         /**
          * Create a new Math32.
@@ -45,7 +45,7 @@ class BigMathParseTest extends JsonpParseTest {
     /**
      * Unit test using JsonpValueFactory.BIGMATH64.
      */
-    static final class Math64 extends JsonpParseTest {
+    static final class Math64 extends AbstractJsonpParseTest {
 
         /**
          * Create a new Math64.
@@ -58,7 +58,7 @@ class BigMathParseTest extends JsonpParseTest {
     /**
      * Unit test using JsonpValueFactory.BIGMATH128.
      */
-    static final class Math128 extends JsonpParseTest {
+    static final class Math128 extends AbstractJsonpParseTest {
 
         /**
          * Create a new Math128.
@@ -71,7 +71,7 @@ class BigMathParseTest extends JsonpParseTest {
     /**
      * Unit test using JsonpValueFactory.BIGMATH32.
      */
-    static final class Decimal32 extends JsonpParseTest {
+    static final class Decimal32 extends AbstractJsonpParseTest {
 
         /**
          * Create a new Decimal32.
@@ -88,7 +88,7 @@ class BigMathParseTest extends JsonpParseTest {
     /**
      * Unit test using JsonpValueFactory.BIGMATH64.
      */
-    static final class Decimal64 extends JsonpParseTest {
+    static final class Decimal64 extends AbstractJsonpParseTest {
 
         /**
          * Create a new Decimal64.
@@ -105,7 +105,7 @@ class BigMathParseTest extends JsonpParseTest {
     /**
      * Unit test using JsonpValueFactory.BIGMATH128.
      */
-    static final class Decimal128 extends JsonpParseTest {
+    static final class Decimal128 extends AbstractJsonpParseTest {
 
         /**
          * Create a new Decimal128.

--- a/module/jsonurl-jsr374/src/test/java/org/jsonurl/jsonp/DoubleParseTest.java
+++ b/module/jsonurl-jsr374/src/test/java/org/jsonurl/jsonp/DoubleParseTest.java
@@ -24,7 +24,7 @@ package org.jsonurl.jsonp;
  * @author David MacCormack
  * @since 2019-09-01
  */
-public class DoubleParseTest extends JsonpParseTest {
+public class DoubleParseTest extends AbstractJsonpParseTest {
 
     /**
      * Create a new DoubleParseTest.

--- a/module/jsonurl-jsr374/src/test/java/org/jsonurl/jsonp/JsonpWriteTest.java
+++ b/module/jsonurl-jsr374/src/test/java/org/jsonurl/jsonp/JsonpWriteTest.java
@@ -17,6 +17,7 @@
 
 package org.jsonurl.jsonp;
 
+import java.io.IOException;
 import java.io.StringReader;
 import java.io.StringWriter;
 import javax.json.Json;
@@ -45,16 +46,16 @@ public class JsonpWriteTest extends AbstractJsonApiWriteTest<
 
 
     @Override
-    public JsonArray newArray(String s) {
-        try (JsonReader r = Json.createReader(new StringReader(s))) {
-            return r.readArray();
+    public JsonArray newArray(String text) {
+        try (JsonReader json = Json.createReader(new StringReader(text))) {
+            return json.readArray();
         }
     }
 
     @Override
-    public JsonObject newObject(String s) {
-        try (JsonReader r = Json.createReader(new StringReader(s))) {
-            return r.readObject();
+    public JsonObject newObject(String text) {
+        try (JsonReader json = Json.createReader(new StringReader(text))) {
+            return json.readObject();
         }
     }
 
@@ -81,8 +82,8 @@ public class JsonpWriteTest extends AbstractJsonApiWriteTest<
     }
 
     @Override
-    public void write(JsonTextBuilder<?, ?> out, JsonValue value)
-            throws Exception {
-        JsonUrlWriter.write(out, value);
+    public void write(JsonTextBuilder<?, ?> dest, JsonValue value)
+            throws IOException {
+        JsonUrlWriter.write(dest, value);
     }
 }

--- a/module/jsonurl-jsr374/src/test/java/org/jsonurl/jsonp/PrimitiveParseTest.java
+++ b/module/jsonurl-jsr374/src/test/java/org/jsonurl/jsonp/PrimitiveParseTest.java
@@ -24,7 +24,7 @@ package org.jsonurl.jsonp;
  * @author David MacCormack
  * @since 2019-09-01
  */
-public class PrimitiveParseTest extends JsonpParseTest {
+public class PrimitiveParseTest extends AbstractJsonpParseTest {
 
     /**
      * Create a new PrimitiveParseTest.

--- a/module/pom.xml
+++ b/module/pom.xml
@@ -80,6 +80,7 @@
 
     <checkstyle.config.file>config/checkstyle.xml</checkstyle.config.file>
     <checkstyle.config.module.location>../../${checkstyle.config.file}</checkstyle.config.module.location>
+    <pmd.version>6.28.0</pmd.version>
     <pmd.config.file>config/pmd-ruleset.xml</pmd.config.file>
     <pmd.config.module.location>../../${pmd.config.file}</pmd.config.module.location>
     <jacoco.minimum.coverage>0.40</jacoco.minimum.coverage>
@@ -203,6 +204,28 @@
         <plugin>
           <artifactId>maven-pmd-plugin</artifactId>
           <version>${maven.pmd.plugin}</version>
+          <dependencies>
+            <dependency>
+              <groupId>net.sourceforge.pmd</groupId>
+              <artifactId>pmd-core</artifactId>
+              <version>${pmd.version}</version>
+            </dependency>
+            <dependency>
+              <groupId>net.sourceforge.pmd</groupId>
+              <artifactId>pmd-java</artifactId>
+              <version>${pmd.version}</version>
+            </dependency>
+            <dependency>
+              <groupId>net.sourceforge.pmd</groupId>
+              <artifactId>pmd-java8</artifactId>
+              <version>${pmd.version}</version>
+            </dependency>
+            <dependency>
+              <groupId>net.sourceforge.pmd</groupId>
+              <artifactId>pmd-jsp</artifactId>
+              <version>${pmd.version}</version>
+            </dependency>
+          </dependencies>
           <configuration>
             <sourceEncoding>${char.encoding}</sourceEncoding>
             <targetJdk>${jdk.version}</targetJdk>


### PR DESCRIPTION
This commit touches almost everything, but most of the changes are
superficial:
  - rename of method arguments or private fields
  - add/update comments
  - removal of redundant class/method modifiers

A number of deprecated rules have been removed from the rules file.

The parent POM was modified to depend on a specific version of PMD, as
even though the maven plugin is the latest it defaults to an older
version of PMD.

There is one breaking change. A couple of unit test class
names have been modified, per-PMD rules, to have an "Abstract"
prefix.