### PR TITLE
chore: Separate nested unit tests from their abstract base class

### DIFF
--- a/module/jsonurl-core/src/test/java/org/jsonurl/j2se/AbstractJavaValueFactoryParseTest.java
+++ b/module/jsonurl-core/src/test/java/org/jsonurl/j2se/AbstractJavaValueFactoryParseTest.java
@@ -22,13 +22,9 @@ import java.util.List;
 import java.util.Map;
 import org.jsonurl.AbstractParseTest;
 import org.jsonurl.BigMathProvider.BigIntegerOverflow;
-import org.junit.jupiter.api.Nested;
 
 /**
- * Abstract base class for parser tests.
- * 
- * <p>One specialization of this class may be created for each
- * factory constant defined in {@link JavaValueFactory}.
+ * Abstract base class for Parser + JavaValueFactory unit tests.
  * 
  * @author jsonurl.org
  * @author David MacCormack
@@ -45,87 +41,6 @@ abstract class AbstractJavaValueFactoryParseTest extends AbstractParseTest<
         Number,
         Object,
         String> {
-    
-    /**
-     * Unit test using JavaValueFactory.PRIMITIVE.
-     */
-    @Nested
-    static class PrimitiveParseTest extends AbstractJavaValueFactoryParseTest {
-
-        /**
-         * Create a new PrimitiveParseTest.
-         */
-        public PrimitiveParseTest() {
-            super(JavaValueFactory.PRIMITIVE);
-        }
-    }
-    
-    /**
-     * Unit test using JavaValueFactory.DOUBLE.
-     */
-    @Nested
-    static class DoubleParseTest extends AbstractJavaValueFactoryParseTest {
-
-        /**
-         * Create a new DoubleParseTest.
-         */
-        public DoubleParseTest() {
-            super(JavaValueFactory.DOUBLE);
-        }
-    }
-    
-    /**
-     * Unit test using JavaValueFactory.BigMathFactory.
-     */
-    @Nested
-    static class BigMathParseTest extends AbstractJavaValueFactoryParseTest {
-        /**
-         * Create a new BigMathParseTest.
-         */
-        BigMathParseTest() {
-            super(new JavaValueFactory.BigMathFactory(null, null, null, null));
-        }
-    }
-    
-
-    /**
-     * Unit test using JavaValueFactory.BIGMATH32.
-     */
-    @Nested
-    static class BigMathParseTest32 extends AbstractJavaValueFactoryParseTest {
-        /**
-         * Create a new BigMathParseTest32.
-         */
-        BigMathParseTest32() {
-            super(JavaValueFactory.BIGMATH32);
-        }
-    }
-
-    /**
-     * Unit test using JavaValueFactory.BIGMATH64.
-     */
-    @Nested
-    static class BigMathParseTest64 extends AbstractJavaValueFactoryParseTest {
-        /**
-         * Create a new BigMathParseTest64.
-         */
-        BigMathParseTest64() {
-            super(JavaValueFactory.BIGMATH64);
-        }
-    }
-
-    /**
-     * Unit test using JavaValueFactory.BIGMATH128.
-     */
-    @Nested
-    static class BigMathParseTest128 extends AbstractJavaValueFactoryParseTest {
-        /**
-         * Create a new BigMathParseTest128.
-         */
-        BigMathParseTest128() {
-            super(JavaValueFactory.BIGMATH128);
-        }
-    }
 
     /**
      * Create a new JavaValueFactoryParseTest.

--- a/module/jsonurl-core/src/test/java/org/jsonurl/j2se/AbstractJavaValueWriteTest.java
+++ b/module/jsonurl-core/src/test/java/org/jsonurl/j2se/AbstractJavaValueWriteTest.java
@@ -22,10 +22,9 @@ import java.util.List;
 import java.util.Map;
 import org.jsonurl.AbstractWriteTest;
 import org.jsonurl.JsonTextBuilder;
-import org.junit.jupiter.api.Nested;
 
 /**
- * Unit test for writing JSON&#x2192;URL text.
+ * Abstract base class for JsonUrlStringBuilder + JavaValueFactory unit tests.
  *
  * @author jsonurl.org
  * @author David MacCormack
@@ -39,79 +38,6 @@ public abstract class AbstractJavaValueWriteTest
             List<Object>,
             Map<String,Object>,
             Map<String,Object>> {
-
-    /**
-     * JavaValueFactory.PRIMITIVE JavaValueWriteTest.
-     */
-    @Nested
-    static class PrimitiveWriteTest extends AbstractJavaValueWriteTest {
-
-        @Override
-        public JavaValueFactory getFactory() {
-            return JavaValueFactory.PRIMITIVE;
-        }
-        
-    }
-
-    /**
-     * JavaValueFactory.DOUBLE JavaValueWriteTest.
-     */
-    @Nested
-    static class DoubleWriteTest extends AbstractJavaValueWriteTest {
-
-        @Override
-        public JavaValueFactory getFactory() {
-            return JavaValueFactory.DOUBLE;
-        }
-    }
-
-    /**
-     * JavaValueFactory.BIGMATH32 JavaValueWriteTest.
-     */
-    @Nested
-    static class BigMathWriteTest extends AbstractJavaValueWriteTest {
-
-        @Override
-        public JavaValueFactory getFactory() {
-            return new JavaValueFactory.BigMathFactory(null, null, null, null);
-        }
-    }
-
-    /**
-     * JavaValueFactory.BIGMATH32 JavaValueWriteTest.
-     */
-    @Nested
-    static class BigMathWriteTest32 extends AbstractJavaValueWriteTest {
-
-        @Override
-        public JavaValueFactory getFactory() {
-            return JavaValueFactory.BIGMATH32;
-        }
-    }
-
-    /**
-     * JavaValueFactory.BIGMATH64 JavaValueWriteTest.
-     */
-    @Nested
-    static class BigMathWriteTest64 extends AbstractJavaValueWriteTest {
-
-        @Override
-        public JavaValueFactory getFactory() {
-            return JavaValueFactory.BIGMATH64;
-        }
-    }
-
-    /**
-     * JavaValueFactory.BIGMATH128 JavaValueWriteTest.
-     */
-    @Nested
-    static class BigMathWriteTest128 extends AbstractJavaValueWriteTest {
-
-        @Override
-        public JavaValueFactory getFactory() {
-            return JavaValueFactory.BIGMATH128;
-        }
-    }
 
     @Override
     protected <I,R> boolean write(

--- a/module/jsonurl-core/src/test/java/org/jsonurl/j2se/JavaValueFactoryParseTest.java
+++ b/module/jsonurl-core/src/test/java/org/jsonurl/j2se/JavaValueFactoryParseTest.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2019-2020 David MacCormack
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.jsonurl.j2se;
+
+import org.junit.jupiter.api.Nested;
+
+/**
+ * Unit tests for Parser + JavaValueFactory.
+ * 
+ * @author jsonurl.org
+ * @author David MacCormack
+ * @since 2019-09-01
+ */
+class JavaValueFactoryParseTest  {
+    
+    /**
+     * Unit test using JavaValueFactory.PRIMITIVE.
+     */
+    @Nested
+    class PrimitiveParseTest extends AbstractJavaValueFactoryParseTest {
+
+        /**
+         * Create a new PrimitiveParseTest.
+         */
+        public PrimitiveParseTest() {
+            super(JavaValueFactory.PRIMITIVE);
+        }
+    }
+    
+    /**
+     * Unit test using JavaValueFactory.DOUBLE.
+     */
+    @Nested
+    class DoubleParseTest extends AbstractJavaValueFactoryParseTest {
+
+        /**
+         * Create a new DoubleParseTest.
+         */
+        public DoubleParseTest() {
+            super(JavaValueFactory.DOUBLE);
+        }
+    }
+    
+    /**
+     * Unit test using JavaValueFactory.BigMathFactory.
+     */
+    @Nested
+    class BigMathParseTest extends AbstractJavaValueFactoryParseTest {
+        /**
+         * Create a new BigMathParseTest.
+         */
+        BigMathParseTest() {
+            super(new JavaValueFactory.BigMathFactory(null, null, null, null));
+        }
+    }
+    
+
+    /**
+     * Unit test using JavaValueFactory.BIGMATH32.
+     */
+    @Nested
+    class BigMathParseTest32 extends AbstractJavaValueFactoryParseTest {
+        /**
+         * Create a new BigMathParseTest32.
+         */
+        BigMathParseTest32() {
+            super(JavaValueFactory.BIGMATH32);
+        }
+    }
+
+    /**
+     * Unit test using JavaValueFactory.BIGMATH64.
+     */
+    @Nested
+    class BigMathParseTest64 extends AbstractJavaValueFactoryParseTest {
+        /**
+         * Create a new BigMathParseTest64.
+         */
+        BigMathParseTest64() {
+            super(JavaValueFactory.BIGMATH64);
+        }
+    }
+
+    /**
+     * Unit test using JavaValueFactory.BIGMATH128.
+     */
+    @Nested
+    class BigMathParseTest128 extends AbstractJavaValueFactoryParseTest {
+        /**
+         * Create a new BigMathParseTest128.
+         */
+        BigMathParseTest128() {
+            super(JavaValueFactory.BIGMATH128);
+        }
+    }
+}

--- a/module/jsonurl-core/src/test/java/org/jsonurl/j2se/JavaValueWriteTest.java
+++ b/module/jsonurl-core/src/test/java/org/jsonurl/j2se/JavaValueWriteTest.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2019-2020 David MacCormack
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.jsonurl.j2se;
+
+import org.junit.jupiter.api.Nested;
+
+/**
+ * Unit tests for JsonUrlStringBuilder + JavaValueFactory.
+ *
+ * @author jsonurl.org
+ * @author David MacCormack
+ * @since 2020-09-01
+ */
+class JavaValueWriteTest {
+
+    /**
+     * JavaValueFactory.PRIMITIVE JavaValueWriteTest.
+     */
+    @Nested
+    class PrimitiveWriteTest extends AbstractJavaValueWriteTest {
+
+        @Override
+        public JavaValueFactory getFactory() {
+            return JavaValueFactory.PRIMITIVE;
+        }
+        
+    }
+
+    /**
+     * JavaValueFactory.DOUBLE JavaValueWriteTest.
+     */
+    @Nested
+    class DoubleWriteTest extends AbstractJavaValueWriteTest {
+
+        @Override
+        public JavaValueFactory getFactory() {
+            return JavaValueFactory.DOUBLE;
+        }
+    }
+
+    /**
+     * JavaValueFactory.BIGMATH32 JavaValueWriteTest.
+     */
+    @Nested
+    class BigMathWriteTest extends AbstractJavaValueWriteTest {
+
+        @Override
+        public JavaValueFactory getFactory() {
+            return new JavaValueFactory.BigMathFactory(null, null, null, null);
+        }
+    }
+
+    /**
+     * JavaValueFactory.BIGMATH32 JavaValueWriteTest.
+     */
+    @Nested
+    class BigMathWriteTest32 extends AbstractJavaValueWriteTest {
+
+        @Override
+        public JavaValueFactory getFactory() {
+            return JavaValueFactory.BIGMATH32;
+        }
+    }
+
+    /**
+     * JavaValueFactory.BIGMATH64 JavaValueWriteTest.
+     */
+    @Nested
+    class BigMathWriteTest64 extends AbstractJavaValueWriteTest {
+
+        @Override
+        public JavaValueFactory getFactory() {
+            return JavaValueFactory.BIGMATH64;
+        }
+    }
+
+    /**
+     * JavaValueFactory.BIGMATH128 JavaValueWriteTest.
+     */
+    @Nested
+    class BigMathWriteTest128 extends AbstractJavaValueWriteTest {
+
+        @Override
+        public JavaValueFactory getFactory() {
+            return JavaValueFactory.BIGMATH128;
+        }
+    }
+}

--- a/module/jsonurl-jsonorg/src/test/java/org/jsonurl/jsonorg/AbstractJsonOrgParseTest.java
+++ b/module/jsonurl-jsonorg/src/test/java/org/jsonurl/jsonorg/AbstractJsonOrgParseTest.java
@@ -24,13 +24,9 @@ import org.json.JSONObject;
 import org.jsonurl.AbstractParseTest;
 import org.jsonurl.BigMathProvider.BigIntegerOverflow;
 import org.jsonurl.ValueFactory;
-import org.junit.jupiter.api.Nested;
 
 /**
- * Abstract base class for parser tests.
- *
- * <p>A specialization of this class may be created for each
- * factory constant defined in {@link JsonOrgValueFactory}.
+ * Abstract base class for Parser + JsonOrgValueFactory unit tests.
  * 
  * @author jsonurl.org
  * @author David MacCormack
@@ -49,93 +45,9 @@ abstract class AbstractJsonOrgParseTest extends AbstractParseTest<
     String> {
 
     /**
-     * Unit test using JsonOrgValueFactory.PRIMITIVE.
-     */
-    @Nested
-    static class PrimitiveParseTest extends AbstractJsonOrgParseTest {
-        /**
-         * Create a new PrimitiveParseTest.
-         */
-        public PrimitiveParseTest() {
-            super(JsonOrgValueFactory.PRIMITIVE);
-        }
-    }
-    
-    /**
-     * Unit test using JsonOrgValueFactory.DOUBLE.
-     */
-    @Nested
-    static class DoubleParseTest extends AbstractJsonOrgParseTest {
-        /**
-         * Create a new DoubleParseTest.
-         */
-        public DoubleParseTest() {
-            super(JsonOrgValueFactory.DOUBLE);
-        }
-    }
-    
-    /**
-     * Unit test using JsonOrgValueFactory.BigMathFactory.
-     *
-     * @author jsonurl.org
-     * @author David MacCormack
-     * @since 2019-09-01
-     */
-    @Nested
-    static class BigMathParseTest extends AbstractJsonOrgParseTest {
-        /**
-         * Create a new BigMathParseTest.
-         */
-        public BigMathParseTest() {
-            super(new JsonOrgValueFactory.BigMathFactory(null, null, null, null));
-        }
-    }
-    
-
-    /**
-     * Unit test using JsonOrgValueFactory.BIGMATH32.
-     */
-    @Nested
-    static final class BigMathParseTest32 extends AbstractJsonOrgParseTest {
-        /**
-         * Create a new BigMathParseTest32.
-         */
-        public BigMathParseTest32() {
-            super(JsonOrgValueFactory.BIGMATH32);
-        }
-    }
-    
-    /**
-     * Unit test using JsonOrgValueFactory.BIGMATH64.
-     */
-    @Nested
-    static final class BigMathParseTest64 extends AbstractJsonOrgParseTest {
-        /**
-         * Create a new BigMathParseTest64.
-         */
-        public BigMathParseTest64() {
-            super(JsonOrgValueFactory.BIGMATH64);
-        }
-    }
-
-    /**
-     * Unit test using JsonOrgValueFactory.BIGMATH128.
-     */
-    @Nested
-    static final class BigMathParseTest128 extends AbstractJsonOrgParseTest {
-        /**
-         * Create a new BigMathParseTest128.
-         */
-        public BigMathParseTest128() {
-            super(JsonOrgValueFactory.BIGMATH128);
-        }
-    }
-
-
-    /**
      * Create a new JsonOrgParseTest.
      */
-    public AbstractJsonOrgParseTest(JsonOrgValueFactory factory) {
+    AbstractJsonOrgParseTest(JsonOrgValueFactory factory) {
         super(factory);
     }
     

--- a/module/jsonurl-jsonorg/src/test/java/org/jsonurl/jsonorg/AbstractJsonOrgWriteTest.java
+++ b/module/jsonurl-jsonorg/src/test/java/org/jsonurl/jsonorg/AbstractJsonOrgWriteTest.java
@@ -22,16 +22,15 @@ import org.json.JSONArray;
 import org.json.JSONObject;
 import org.jsonurl.AbstractWriteTest;
 import org.jsonurl.JsonTextBuilder;
-import org.junit.jupiter.api.Nested;
 
 /**
- * Unit test for writing JSON&#x2192;URL text.
+ * Abstract base class for JsonUrlStringBuilder + JsonOrgValueFactory unit tests.
  *
  * @author jsonurl.org
  * @author David MacCormack
  * @since 2020-09-01
  */
-public abstract class AbstractJsonOrgWriteTest
+abstract class AbstractJsonOrgWriteTest
         extends AbstractWriteTest<
             Object,
             Object,
@@ -39,79 +38,6 @@ public abstract class AbstractJsonOrgWriteTest
             JSONArray,
             JSONObject,
             JSONObject> {
-
-    /**
-     * JavaValueFactory.PRIMITIVE JavaValueWriteTest.
-     */
-    @Nested
-    static class PrimitiveWriteTest extends AbstractJsonOrgWriteTest {
-
-        @Override
-        public JsonOrgValueFactory getFactory() {
-            return JsonOrgValueFactory.PRIMITIVE;
-        }
-        
-    }
-
-    /**
-     * JavaValueFactory.DOUBLE JavaValueWriteTest.
-     */
-    @Nested
-    static class DoubleWriteTest extends AbstractJsonOrgWriteTest {
-
-        @Override
-        public JsonOrgValueFactory getFactory() {
-            return JsonOrgValueFactory.DOUBLE;
-        }
-    }
-
-    /**
-     * JavaValueFactory.BIGMATH32 JavaValueWriteTest.
-     */
-    @Nested
-    static class BigMathWriteTest extends AbstractJsonOrgWriteTest {
-
-        @Override
-        public JsonOrgValueFactory getFactory() {
-            return new JsonOrgValueFactory.BigMathFactory(null, null, null, null);
-        }
-    }
-
-    /**
-     * JavaValueFactory.BIGMATH32 JavaValueWriteTest.
-     */
-    @Nested
-    static class BigMathWriteTest32 extends AbstractJsonOrgWriteTest {
-
-        @Override
-        public JsonOrgValueFactory getFactory() {
-            return JsonOrgValueFactory.BIGMATH32;
-        }
-    }
-
-    /**
-     * JavaValueFactory.BIGMATH64 JavaValueWriteTest.
-     */
-    @Nested
-    static class BigMathWriteTest64 extends AbstractJsonOrgWriteTest {
-
-        @Override
-        public JsonOrgValueFactory getFactory() {
-            return JsonOrgValueFactory.BIGMATH64;
-        }
-    }
-
-    /**
-     * JavaValueFactory.BIGMATH128 JavaValueWriteTest.
-     */
-    @Nested
-    static class BigMathWriteTest128 extends AbstractJsonOrgWriteTest {
-
-        @Override
-        public JsonOrgValueFactory getFactory() {
-            return JsonOrgValueFactory.BIGMATH128;
-        }
-    }
 
     @Override
     protected <I,R> boolean write(

--- a/module/jsonurl-jsonorg/src/test/java/org/jsonurl/jsonorg/JsonOrgParseTest.java
+++ b/module/jsonurl-jsonorg/src/test/java/org/jsonurl/jsonorg/JsonOrgParseTest.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2019 David MacCormack
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.jsonurl.jsonorg;
+
+import org.junit.jupiter.api.Nested;
+
+/**
+ * Unit tests for Parser + JsonOrgValueFactory.
+ * 
+ * @author jsonurl.org
+ * @author David MacCormack
+ * @since 2019-09-01
+ */
+class JsonOrgParseTest {
+
+    /**
+     * Unit test using JsonOrgValueFactory.PRIMITIVE.
+     */
+    @Nested
+    class PrimitiveParseTest extends AbstractJsonOrgParseTest {
+        /**
+         * Create a new PrimitiveParseTest.
+         */
+        public PrimitiveParseTest() {
+            super(JsonOrgValueFactory.PRIMITIVE);
+        }
+    }
+    
+    /**
+     * Unit test using JsonOrgValueFactory.DOUBLE.
+     */
+    @Nested
+    class DoubleParseTest extends AbstractJsonOrgParseTest {
+        /**
+         * Create a new DoubleParseTest.
+         */
+        public DoubleParseTest() {
+            super(JsonOrgValueFactory.DOUBLE);
+        }
+    }
+    
+    /**
+     * Unit test using JsonOrgValueFactory.BigMathFactory.
+     */
+    @Nested
+    class BigMathParseTest extends AbstractJsonOrgParseTest {
+        /**
+         * Create a new BigMathParseTest.
+         */
+        public BigMathParseTest() {
+            super(new JsonOrgValueFactory.BigMathFactory(null, null, null, null));
+        }
+    }
+    
+
+    /**
+     * Unit test using JsonOrgValueFactory.BIGMATH32.
+     */
+    @Nested
+    class BigMathParseTest32 extends AbstractJsonOrgParseTest {
+        /**
+         * Create a new BigMathParseTest32.
+         */
+        public BigMathParseTest32() {
+            super(JsonOrgValueFactory.BIGMATH32);
+        }
+    }
+    
+    /**
+     * Unit test using JsonOrgValueFactory.BIGMATH64.
+     */
+    @Nested
+    class BigMathParseTest64 extends AbstractJsonOrgParseTest {
+        /**
+         * Create a new BigMathParseTest64.
+         */
+        public BigMathParseTest64() {
+            super(JsonOrgValueFactory.BIGMATH64);
+        }
+    }
+
+    /**
+     * Unit test using JsonOrgValueFactory.BIGMATH128.
+     */
+    @Nested
+    class BigMathParseTest128 extends AbstractJsonOrgParseTest {
+        /**
+         * Create a new BigMathParseTest128.
+         */
+        public BigMathParseTest128() {
+            super(JsonOrgValueFactory.BIGMATH128);
+        }
+    }
+}

--- a/module/jsonurl-jsonorg/src/test/java/org/jsonurl/jsonorg/JsonOrgWriteTest.java
+++ b/module/jsonurl-jsonorg/src/test/java/org/jsonurl/jsonorg/JsonOrgWriteTest.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2019-2020 David MacCormack
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.jsonurl.jsonorg;
+
+import org.junit.jupiter.api.Nested;
+
+/**
+ * Unit tests for JsonUrlStringBuilder + JsonOrgValueFactory.
+ *
+ * @author jsonurl.org
+ * @author David MacCormack
+ * @since 2020-09-01
+ */
+class JsonOrgWriteTest {
+
+    /**
+     * JsonOrgValueFactory.PRIMITIVE JsonOrgWriteTest.
+     */
+    @Nested
+    class PrimitiveWriteTest extends AbstractJsonOrgWriteTest {
+
+        @Override
+        public JsonOrgValueFactory getFactory() {
+            return JsonOrgValueFactory.PRIMITIVE;
+        }
+        
+    }
+
+    /**
+     * JsonOrgValueFactory.DOUBLE JsonOrgWriteTest.
+     */
+    @Nested
+    class DoubleWriteTest extends AbstractJsonOrgWriteTest {
+
+        @Override
+        public JsonOrgValueFactory getFactory() {
+            return JsonOrgValueFactory.DOUBLE;
+        }
+    }
+
+    /**
+     * JsonOrgValueFactory.BIGMATH32 JsonOrgWriteTest.
+     */
+    @Nested
+    class BigMathWriteTest extends AbstractJsonOrgWriteTest {
+
+        @Override
+        public JsonOrgValueFactory getFactory() {
+            return new JsonOrgValueFactory.BigMathFactory(null, null, null, null);
+        }
+    }
+
+    /**
+     * JsonOrgValueFactory.BIGMATH32 JsonOrgWriteTest.
+     */
+    @Nested
+    class BigMathWriteTest32 extends AbstractJsonOrgWriteTest {
+
+        @Override
+        public JsonOrgValueFactory getFactory() {
+            return JsonOrgValueFactory.BIGMATH32;
+        }
+    }
+
+    /**
+     * JsonOrgValueFactory.BIGMATH64 JsonOrgWriteTest.
+     */
+    @Nested
+    class BigMathWriteTest64 extends AbstractJsonOrgWriteTest {
+
+        @Override
+        public JsonOrgValueFactory getFactory() {
+            return JsonOrgValueFactory.BIGMATH64;
+        }
+    }
+
+    /**
+     * JsonOrgValueFactory.BIGMATH128 JsonOrgWriteTest.
+     */
+    @Nested
+    class BigMathWriteTest128 extends AbstractJsonOrgWriteTest {
+
+        @Override
+        public JsonOrgValueFactory getFactory() {
+            return JsonOrgValueFactory.BIGMATH128;
+        }
+    }
+}

--- a/module/jsonurl-jsr374/src/test/java/org/jsonurl/jsonp/AbstractJsonpParseTest.java
+++ b/module/jsonurl-jsr374/src/test/java/org/jsonurl/jsonp/AbstractJsonpParseTest.java
@@ -27,17 +27,12 @@ import javax.json.JsonString;
 import javax.json.JsonStructure;
 import javax.json.JsonValue;
 import org.jsonurl.AbstractParseTest;
-import org.jsonurl.BigMathProvider;
 import org.jsonurl.BigMathProvider.BigIntegerOverflow;
 import org.jsonurl.ValueFactory;
-import org.junit.jupiter.api.Nested;
 
 
 /**
- * Abstract base class for parser tests.
- *
- * <p>A specialization of this class may be created for each
- * factory constant defined in {@link JsonOrgValueFactory}.
+ * Abstract base class for Parser + JsonpValueFactory unit tests.
  * 
  * @author jsonurl.org
  * @author David MacCormack
@@ -54,138 +49,6 @@ abstract class AbstractJsonpParseTest extends AbstractParseTest<
         JsonNumber,
         JsonValue,
         JsonString> {
-
-    /**
-     * Unit test using JsonpValueFactory.PRIMITIVE.
-     */
-    @Nested
-    static class PrimitiveParseTest extends AbstractJsonpParseTest {
-        /**
-         * Create a new PrimitiveParseTest.
-         */
-        public PrimitiveParseTest() {
-            super(JsonpValueFactory.PRIMITIVE);
-        }
-    }
-    
-    /**
-     * Unit test using JsonpValueFactory.DOUBLE.
-     */
-    @Nested
-    static class DoubleParseTest extends AbstractJsonpParseTest {
-        /**
-         * Create a new DoubleParseTest.
-         */
-        public DoubleParseTest() {
-            super(JsonpValueFactory.DOUBLE);
-        }
-    }
-
-    /**
-     * Unit test using JsonpValueFactory.BigMathFactory.
-     *
-     * @author jsonurl.org
-     * @author David MacCormack
-     * @since 2019-09-01
-     */
-    @Nested
-    static class BigMathParseTest extends AbstractJsonpParseTest {
-
-        /**
-         * Create a new BigMathParseTest.
-         */
-        BigMathParseTest() {
-            super(new JsonpValueFactory.BigMathFactory(null, null, null, null));
-        }
-    }
-
-    /**
-     * Unit test using JsonpValueFactory.BIGMATH32.
-     */
-    @Nested
-    static final class BigMathParseTest32 extends AbstractJsonpParseTest {
-        /**
-         * Create a new BigMathParseTest32.
-         */
-        BigMathParseTest32() {
-            super(JsonpValueFactory.BIGMATH32);
-        }
-    }
-
-    /**
-     * Unit test using JsonpValueFactory.BIGMATH64.
-     */
-    @Nested
-    static final class BigMathParseTest64 extends AbstractJsonpParseTest {
-        /**
-         * Create a new BigMathParseTest64.
-         */
-        BigMathParseTest64() {
-            super(JsonpValueFactory.BIGMATH64);
-        }
-    }
-
-    /**
-     * Unit test using JsonpValueFactory.BIGMATH128.
-     */
-    @Nested
-    static final class BigMathParseTest128 extends AbstractJsonpParseTest {
-        /**
-         * Create a new BigMathParseTest128.
-         */
-        BigMathParseTest128() {
-            super(JsonpValueFactory.BIGMATH128);
-        }
-    }
-    
-    /**
-     * Unit test using JsonpValueFactory.BIGMATH32.
-     */
-    static final class BigDecimalParseTest32 extends AbstractJsonpParseTest {
-        /**
-         * Create a new BigDecimalParseTest32.
-         */
-        BigDecimalParseTest32() {
-            super(new JsonpValueFactory.BigMathFactory(
-                MathContext.DECIMAL32,
-                BigMathProvider.BIG_INTEGER32_BOUNDARY_NEG,
-                BigMathProvider.BIG_INTEGER32_BOUNDARY_POS,
-                null));
-        }
-    }
-
-    /**
-     * Unit test using JsonpValueFactory.BIGMATH64.
-     */
-    static final class BigDecimalParseTest64 extends AbstractJsonpParseTest {
-        /**
-         * Create a new BigDecimalParseTest64.
-         */
-        BigDecimalParseTest64() {
-            super(new JsonpValueFactory.BigMathFactory(
-                MathContext.DECIMAL64,
-                BigMathProvider.BIG_INTEGER64_BOUNDARY_NEG,
-                BigMathProvider.BIG_INTEGER64_BOUNDARY_POS,
-                null));
-        }
-    }
-
-    /**
-     * Unit test using JsonpValueFactory.BIGMATH128.
-     */
-    static final class BigDecimalParseTest128 extends AbstractJsonpParseTest {
-
-        /**
-         * Create a new BigDecimalParseTest128.
-         */
-        BigDecimalParseTest128() {
-            super(new JsonpValueFactory.BigMathFactory(
-                MathContext.DECIMAL128,
-                BigMathProvider.BIG_INTEGER128_BOUNDARY_NEG,
-                BigMathProvider.BIG_INTEGER128_BOUNDARY_POS,
-                null));
-        }
-    }
 
     /**
      * Create a new JsonpParseTest.

--- a/module/jsonurl-jsr374/src/test/java/org/jsonurl/jsonp/AbstractJsonpWriteTest.java
+++ b/module/jsonurl-jsr374/src/test/java/org/jsonurl/jsonp/AbstractJsonpWriteTest.java
@@ -26,16 +26,15 @@ import javax.json.JsonStructure;
 import javax.json.JsonValue;
 import org.jsonurl.AbstractWriteTest;
 import org.jsonurl.JsonTextBuilder;
-import org.junit.jupiter.api.Nested;
 
 /**
- * Unit test for writing JSON&#x2192;URL text.
+ * Abstract base class for JsonUrlStringBuilder + JsonpValueFactory unit tests.
  *
  * @author jsonurl.org
  * @author David MacCormack
  * @since 2020-09-01
  */
-public abstract class AbstractJsonpWriteTest
+abstract class AbstractJsonpWriteTest
         extends AbstractWriteTest<
             JsonValue,
             JsonStructure,
@@ -43,79 +42,6 @@ public abstract class AbstractJsonpWriteTest
             JsonArray,
             JsonObjectBuilder,
             JsonObject> {
-
-    /**
-     * JavaValueFactory.PRIMITIVE JavaValueWriteTest.
-     */
-    @Nested
-    static class PrimitiveWriteTest extends AbstractJsonpWriteTest {
-
-        @Override
-        public JsonpValueFactory getFactory() {
-            return JsonpValueFactory.PRIMITIVE;
-        }
-        
-    }
-
-    /**
-     * JavaValueFactory.DOUBLE JavaValueWriteTest.
-     */
-    @Nested
-    static class DoubleWriteTest extends AbstractJsonpWriteTest {
-
-        @Override
-        public JsonpValueFactory getFactory() {
-            return JsonpValueFactory.DOUBLE;
-        }
-    }
-
-    /**
-     * JavaValueFactory.BIGMATH32 JavaValueWriteTest.
-     */
-    @Nested
-    static class BigMathWriteTest extends AbstractJsonpWriteTest {
-
-        @Override
-        public JsonpValueFactory getFactory() {
-            return new JsonpValueFactory.BigMathFactory(null, null, null, null);
-        }
-    }
-
-    /**
-     * JavaValueFactory.BIGMATH32 JavaValueWriteTest.
-     */
-    @Nested
-    static class BigMathWriteTest32 extends AbstractJsonpWriteTest {
-
-        @Override
-        public JsonpValueFactory getFactory() {
-            return JsonpValueFactory.BIGMATH32;
-        }
-    }
-
-    /**
-     * JavaValueFactory.BIGMATH64 JavaValueWriteTest.
-     */
-    @Nested
-    static class BigMathWriteTest64 extends AbstractJsonpWriteTest {
-
-        @Override
-        public JsonpValueFactory getFactory() {
-            return JsonpValueFactory.BIGMATH64;
-        }
-    }
-
-    /**
-     * JavaValueFactory.BIGMATH128 JavaValueWriteTest.
-     */
-    @Nested
-    static class BigMathWriteTest128 extends AbstractJsonpWriteTest {
-
-        @Override
-        public JsonpValueFactory getFactory() {
-            return JsonpValueFactory.BIGMATH128;
-        }
-    }
 
     @Override
     public <I,R> boolean write(

--- a/module/jsonurl-jsr374/src/test/java/org/jsonurl/jsonp/JsonpParseTest.java
+++ b/module/jsonurl-jsr374/src/test/java/org/jsonurl/jsonp/JsonpParseTest.java
@@ -1,0 +1,168 @@
+/*
+ * Copyright 2019-2020 David MacCormack
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.jsonurl.jsonp;
+
+import java.math.MathContext;
+import org.jsonurl.BigMathProvider;
+import org.junit.jupiter.api.Nested;
+
+
+/**
+ * Unit tests for Parser + JsonpValueFactory.
+ * 
+ * @author jsonurl.org
+ * @author David MacCormack
+ * @since 2019-09-01
+ */
+class JsonpParseTest {
+
+    /**
+     * Unit test using JsonpValueFactory.PRIMITIVE.
+     */
+    @Nested
+    class PrimitiveParseTest extends AbstractJsonpParseTest {
+        /**
+         * Create a new PrimitiveParseTest.
+         */
+        public PrimitiveParseTest() {
+            super(JsonpValueFactory.PRIMITIVE);
+        }
+    }
+    
+    /**
+     * Unit test using JsonpValueFactory.DOUBLE.
+     */
+    @Nested
+    class DoubleParseTest extends AbstractJsonpParseTest {
+        /**
+         * Create a new DoubleParseTest.
+         */
+        public DoubleParseTest() {
+            super(JsonpValueFactory.DOUBLE);
+        }
+    }
+
+    /**
+     * Unit test using JsonpValueFactory.BigMathFactory.
+     *
+     * @author jsonurl.org
+     * @author David MacCormack
+     * @since 2019-09-01
+     */
+    @Nested
+    class BigMathParseTest extends AbstractJsonpParseTest {
+
+        /**
+         * Create a new BigMathParseTest.
+         */
+        BigMathParseTest() {
+            super(new JsonpValueFactory.BigMathFactory(null, null, null, null));
+        }
+    }
+
+    /**
+     * Unit test using JsonpValueFactory.BIGMATH32.
+     */
+    @Nested
+    class BigMathParseTest32 extends AbstractJsonpParseTest {
+        /**
+         * Create a new BigMathParseTest32.
+         */
+        BigMathParseTest32() {
+            super(JsonpValueFactory.BIGMATH32);
+        }
+    }
+
+    /**
+     * Unit test using JsonpValueFactory.BIGMATH64.
+     */
+    @Nested
+    class BigMathParseTest64 extends AbstractJsonpParseTest {
+        /**
+         * Create a new BigMathParseTest64.
+         */
+        BigMathParseTest64() {
+            super(JsonpValueFactory.BIGMATH64);
+        }
+    }
+
+    /**
+     * Unit test using JsonpValueFactory.BIGMATH128.
+     */
+    @Nested
+    class BigMathParseTest128 extends AbstractJsonpParseTest {
+        /**
+         * Create a new BigMathParseTest128.
+         */
+        BigMathParseTest128() {
+            super(JsonpValueFactory.BIGMATH128);
+        }
+    }
+    
+    /**
+     * Unit test using JsonpValueFactory.BIGMATH32.
+     */
+    @Nested
+    class BigDecimalParseTest32 extends AbstractJsonpParseTest {
+        /**
+         * Create a new BigDecimalParseTest32.
+         */
+        BigDecimalParseTest32() {
+            super(new JsonpValueFactory.BigMathFactory(
+                MathContext.DECIMAL32,
+                BigMathProvider.BIG_INTEGER32_BOUNDARY_NEG,
+                BigMathProvider.BIG_INTEGER32_BOUNDARY_POS,
+                null));
+        }
+    }
+
+    /**
+     * Unit test using JsonpValueFactory.BIGMATH64.
+     */
+    @Nested
+    class BigDecimalParseTest64 extends AbstractJsonpParseTest {
+        /**
+         * Create a new BigDecimalParseTest64.
+         */
+        BigDecimalParseTest64() {
+            super(new JsonpValueFactory.BigMathFactory(
+                MathContext.DECIMAL64,
+                BigMathProvider.BIG_INTEGER64_BOUNDARY_NEG,
+                BigMathProvider.BIG_INTEGER64_BOUNDARY_POS,
+                null));
+        }
+    }
+
+    /**
+     * Unit test using JsonpValueFactory.BIGMATH128.
+     */
+    @Nested
+    class BigDecimalParseTest128 extends AbstractJsonpParseTest {
+
+        /**
+         * Create a new BigDecimalParseTest128.
+         */
+        BigDecimalParseTest128() {
+            super(new JsonpValueFactory.BigMathFactory(
+                MathContext.DECIMAL128,
+                BigMathProvider.BIG_INTEGER128_BOUNDARY_NEG,
+                BigMathProvider.BIG_INTEGER128_BOUNDARY_POS,
+                null));
+        }
+    }
+}

--- a/module/jsonurl-jsr374/src/test/java/org/jsonurl/jsonp/JsonpWriteTest.java
+++ b/module/jsonurl-jsr374/src/test/java/org/jsonurl/jsonp/JsonpWriteTest.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2019-2020 David MacCormack
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.jsonurl.jsonp;
+
+import org.junit.jupiter.api.Nested;
+
+/**
+ * Unit tests for JsonUrlStringBuilder + JsonpValueFactory.
+ *
+ * @author jsonurl.org
+ * @author David MacCormack
+ * @since 2020-09-01
+ */
+class JsonpWriteTest {
+
+    /**
+     * JsonpValueFactory.PRIMITIVE JsonpWriteTest.
+     */
+    @Nested
+    class PrimitiveWriteTest extends AbstractJsonpWriteTest {
+
+        @Override
+        public JsonpValueFactory getFactory() {
+            return JsonpValueFactory.PRIMITIVE;
+        }
+        
+    }
+
+    /**
+     * JsonpValueFactory.DOUBLE JsonpWriteTest.
+     */
+    @Nested
+    class DoubleWriteTest extends AbstractJsonpWriteTest {
+
+        @Override
+        public JsonpValueFactory getFactory() {
+            return JsonpValueFactory.DOUBLE;
+        }
+    }
+
+    /**
+     * JsonpValueFactory.BIGMATH32 JsonpWriteTest.
+     */
+    @Nested
+    class BigMathWriteTest extends AbstractJsonpWriteTest {
+
+        @Override
+        public JsonpValueFactory getFactory() {
+            return new JsonpValueFactory.BigMathFactory(null, null, null, null);
+        }
+    }
+
+    /**
+     * JsonpValueFactory.BIGMATH32 JsonpWriteTest.
+     */
+    @Nested
+    class BigMathWriteTest32 extends AbstractJsonpWriteTest {
+
+        @Override
+        public JsonpValueFactory getFactory() {
+            return JsonpValueFactory.BIGMATH32;
+        }
+    }
+
+    /**
+     * JsonpValueFactory.BIGMATH64 JsonpWriteTest.
+     */
+    @Nested
+    class BigMathWriteTest64 extends AbstractJsonpWriteTest {
+
+        @Override
+        public JsonpValueFactory getFactory() {
+            return JsonpValueFactory.BIGMATH64;
+        }
+    }
+
+    /**
+     * JsonpValueFactory.BIGMATH128 JsonpWriteTest.
+     */
+    @Nested
+    class BigMathWriteTest128 extends AbstractJsonpWriteTest {
+
+        @Override
+        public JsonpValueFactory getFactory() {
+            return JsonpValueFactory.BIGMATH128;
+        }
+    }
+}


### PR DESCRIPTION
Unit tests and coverage worked fine in Eclipse, however, not from
the command line. I'm guessing this has something to do with the
difference in versions for junit and/or Jacoco between the two.

I separated the concrete, nested classes from the abstract base class
and that seemed to fix the problem.