### PR TITLE
chore: Fix sonar.junit.reportPaths and update jacoco.minimum.coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,7 +113,14 @@ jobs:
         key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
         restore-keys: ${{ runner.os }}-m2
     - name: SonarCloud scan of ${{ github.ref }}
-      run: mvn -P jacoco -B -Dsonar.projectKey=jsonurl-java -Dsonar.organization=jsonurl -Dsonar.host.url=https://sonarcloud.io package sonar:sonar
+      run: >
+        mvn -P jacoco -B
+        -Dsonar.projectKey=jsonurl-java
+        -Dsonar.organization=jsonurl
+        -Dsonar.host.url=https://sonarcloud.io
+        -Dsonar.java.libraries=/home/runner/.m2/**/*.jar
+        -Dsonar.java.test.libraries=/home/runner/.m2/**/*.jar
+        package sonar:sonar
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/module/pom.xml
+++ b/module/pom.xml
@@ -83,13 +83,13 @@
     <pmd.version>6.28.0</pmd.version>
     <pmd.config.file>config/pmd-ruleset.xml</pmd.config.file>
     <pmd.config.module.location>../../${pmd.config.file}</pmd.config.module.location>
-    <jacoco.minimum.coverage>0.40</jacoco.minimum.coverage>
+    <jacoco.minimum.coverage>0.80</jacoco.minimum.coverage>
 
     <sonar.organization>jsonurl</sonar.organization>
     <sonar.projectName>JSON->URL Java Artifacts</sonar.projectName>
     <sonar.java.checkstyle.reportPaths>target/checkstyle-result.xml</sonar.java.checkstyle.reportPaths>
     <sonar.java.pmd.reportPaths>target/pmd.xml</sonar.java.pmd.reportPaths>
-    <sonar.junit.reportPaths>**/surefire-reports/*.xml</sonar.junit.reportPaths>
+    <sonar.junit.reportPaths>target/surefire-reports</sonar.junit.reportPaths>
     <sonar.coverage.jacoco.xmlReportPaths>${basedir}/target/site/jacoco/jacoco.xml</sonar.coverage.jacoco.xmlReportPaths>
   </properties>
 


### PR DESCRIPTION
Set sonar.junit.reportPaths to refer specifically to 'target'.

Set jacoco.minimum.coverage to 0.80, which mirrors SonarCloud's quality
gate value.

Set sonar.java.libraries sonar.java.test.libraries, based on the
information logged to the console.