### PR TITLE
update: Use JsonUrlOptions in JsonUrl static's and ParseResultFacade

### DIFF
--- a/module/jsonurl-core/src/main/java/org/jsonurl/JsonUrlTextAppender.java
+++ b/module/jsonurl-core/src/main/java/org/jsonurl/JsonUrlTextAppender.java
@@ -185,17 +185,13 @@ public abstract class JsonUrlTextAppender<A extends Appendable, R> // NOPMD
             return addNull();
         }
 
-        boolean emptyOK = isKey
-                ? isEmptyUnquotedKeyAllowed() : isEmptyUnquotedValueAllowed();
-
         JsonUrl.appendLiteral(
                 out,
                 text,
                 start,
                 end,
                 isKey,
-                emptyOK,
-                isImpliedStringLiterals());
+                this);
 
         return this;
     }

--- a/module/jsonurl-core/src/main/java/org/jsonurl/ParseResultFacade.java
+++ b/module/jsonurl-core/src/main/java/org/jsonurl/ParseResultFacade.java
@@ -68,12 +68,7 @@ interface ParseResultFacade<R> {
     /**
      * Add the given literal.
      */
-    void addLiteral(
-            CharSequence text,
-            int start,
-            int stop,
-            boolean isEmptyUnquotedStringOK,
-            boolean isImpliedStringLiteral);
+    void addLiteral(CharSequence text, int start, int stop);
     
     /**
      * Add a single element array.
@@ -86,22 +81,12 @@ interface ParseResultFacade<R> {
      * endArray();
      * </pre>
      */
-    void addSingleElementArray(
-            CharSequence text,
-            int start,
-            int stop,
-            boolean isEmptyUnquotedStringOK,
-            boolean isImpliedStringLiteral);
+    void addSingleElementArray(CharSequence text, int start, int stop);
     
     /**
      * Add object key.
      */
-    void addObjectKey(
-        CharSequence text,
-        int start,
-        int stop,
-        boolean isEmptyUnquotedStringOK,
-        boolean isImpliedStringLiteral);
+    void addObjectKey(CharSequence text, int start, int stop);
 
     /**
      * Add an array element.
@@ -121,12 +106,7 @@ interface ParseResultFacade<R> {
     /**
      * Get a top-level literal result.
      */
-    R getResult(
-            CharSequence text,
-            int start,
-            int stop,
-            boolean isEmptyUnquotedStringOK,
-            boolean isImpliedStringLiteral);
+    R getResult(CharSequence text, int start, int stop);
 
     /**
      * Test if the given result is valid.
@@ -153,6 +133,5 @@ interface ParseResultFacade<R> {
     ParseResultFacade<R> addMissingValue(
             CharSequence text,
             int start,
-            int stop,
-            boolean isImpliedStringLiteral);
+            int stop);
 }

--- a/module/jsonurl-core/src/main/java/org/jsonurl/Parser.java
+++ b/module/jsonurl-core/src/main/java/org/jsonurl/Parser.java
@@ -260,7 +260,7 @@ public class Parser extends BaseJsonUrlOptions { //NOPMD
 
         return (J)parse(text, 0, text.length(), TYPE_VALUE_OBJECT,
             new ValueFactoryParseResultFacade<>(
-                    factory, null, impliedObject, null));
+                    factory, this, null, impliedObject, null));
     }
 
     /**
@@ -286,7 +286,7 @@ public class Parser extends BaseJsonUrlOptions { //NOPMD
 
         return (J)parse(text, 0, text.length(), TYPE_VALUE_OBJECT,
             new ValueFactoryParseResultFacade<>(
-                    factory, null, impliedObject, mvp));
+                    factory, this, null, impliedObject, mvp));
     }
 
     /**
@@ -313,7 +313,7 @@ public class Parser extends BaseJsonUrlOptions { //NOPMD
 
         return (J)parse(text, off, length, TYPE_VALUE_OBJECT,
             new ValueFactoryParseResultFacade<>(
-                    factory, null, impliedObject, null));
+                    factory, this, null, impliedObject, null));
     }
 
     /**
@@ -341,7 +341,7 @@ public class Parser extends BaseJsonUrlOptions { //NOPMD
 
         return (J)parse(text, off, length, TYPE_VALUE_OBJECT,
             new ValueFactoryParseResultFacade<>(
-                    factory, null, impliedObject, mvp));
+                    factory, this, null, impliedObject, mvp));
     }
 
     /**
@@ -411,7 +411,7 @@ public class Parser extends BaseJsonUrlOptions { //NOPMD
 
         return (A)parse(text, 0, text.length(), TYPE_VALUE_ARRAY,
             new ValueFactoryParseResultFacade<>(
-                    factory, impliedArray, null, null));
+                    factory, this, impliedArray, null, null));
     }
 
     /**
@@ -438,7 +438,7 @@ public class Parser extends BaseJsonUrlOptions { //NOPMD
 
         return (A)parse(text, off, length, TYPE_VALUE_ARRAY,
             new ValueFactoryParseResultFacade<>(
-                    factory, impliedArray, null, null));
+                    factory, this, impliedArray, null, null));
     }
 
     /**
@@ -561,7 +561,8 @@ public class Parser extends BaseJsonUrlOptions { //NOPMD
                 ValueFactory<V,C,ABT,A,JBT,J,B,M,N,S> factory) {
 
         return parse(text, off, length, canReturn,
-            new ValueFactoryParseResultFacade<>(factory, null, null, null));
+            new ValueFactoryParseResultFacade<>(
+                    factory, this, null, null, null));
     }
 
     /**
@@ -611,9 +612,7 @@ public class Parser extends BaseJsonUrlOptions { //NOPMD
                 return result.getResult(
                         text,
                         off,
-                        off,
-                        true,
-                        isImpliedStringLiterals());
+                        off);
             }
             
             //
@@ -676,12 +675,7 @@ public class Parser extends BaseJsonUrlOptions { //NOPMD
                 throw new SyntaxException(MSG_EXPECT_LITERAL);
             }
 
-            R ret = result.getResult(
-                    text,
-                    off,
-                    stop,
-                    isEmptyUnquotedValueAllowed(),
-                    isImpliedStringLiterals());
+            R ret = result.getResult(text, off, stop);
 
             if (canReturn != null && !result.isValid(canReturn, ret)) {
                 throw new SyntaxException(
@@ -858,12 +852,7 @@ public class Parser extends BaseJsonUrlOptions { //NOPMD
                     result
                         .setLocation(litpos)
                         .beginArray()
-                        .addLiteral(
-                                text,
-                                litpos,
-                                pos,
-                                isEmptyUnquotedValueAllowed(),
-                                isImpliedStringLiterals());
+                        .addLiteral(text, litpos, pos);
 
                     continue;
 
@@ -885,12 +874,7 @@ public class Parser extends BaseJsonUrlOptions { //NOPMD
                     
                     result
                         .setLocation(litpos)
-                        .addSingleElementArray(
-                                text,
-                                litpos,
-                                pos,
-                                isEmptyUnquotedValueAllowed(),
-                                isImpliedStringLiterals());
+                        .addSingleElementArray(text, litpos, pos);
 
                     parseDepth--;
                     pos++;
@@ -952,12 +936,7 @@ public class Parser extends BaseJsonUrlOptions { //NOPMD
                     result
                         .setLocation(litpos)
                         .beginObject()
-                        .addObjectKey(
-                                text,
-                                litpos,
-                                pos,
-                                isEmptyUnquotedKeyAllowed(),
-                                isImpliedStringLiterals());
+                        .addObjectKey(text, litpos, pos);
 
                     pos++;
                     continue;
@@ -995,12 +974,7 @@ public class Parser extends BaseJsonUrlOptions { //NOPMD
                 stateStack.set(0, State.ARRAY_AFTER_ELEMENT);
                 result
                     .setLocation(litpos)
-                    .addLiteral(
-                            text,
-                            litpos,
-                            pos,
-                            isEmptyUnquotedValueAllowed(),
-                            isImpliedStringLiterals());
+                    .addLiteral(text, litpos, pos);
 
                 if (pos == stop) {
                     if (parseDepth == 1 && impliedArray) {
@@ -1091,12 +1065,7 @@ public class Parser extends BaseJsonUrlOptions { //NOPMD
                 stateStack.set(0, State.OBJECT_AFTER_ELEMENT);
                 result
                     .setLocation(litpos)
-                    .addLiteral(
-                            text,
-                            litpos,
-                            pos,
-                            isEmptyUnquotedValueAllowed(),
-                            isImpliedStringLiterals());
+                    .addLiteral(text, litpos, pos);
                 
                 if (pos == stop) {
                     if (parseDepth == 1 && impliedObject) {
@@ -1170,8 +1139,7 @@ public class Parser extends BaseJsonUrlOptions { //NOPMD
                             .addMissingValue(
                                     text,
                                     litpos,
-                                    pos,
-                                    isImpliedStringLiterals())
+                                    pos)
                             .addObjectElement()
                             .endObject()
                             .getResult();
@@ -1206,8 +1174,7 @@ public class Parser extends BaseJsonUrlOptions { //NOPMD
                             .addMissingValue(
                                     text,
                                     litpos,
-                                    pos,
-                                    isImpliedStringLiterals());
+                                    pos);
 
                         stateStack.set(0, State.OBJECT_AFTER_ELEMENT);
                         continue;
@@ -1221,12 +1188,7 @@ public class Parser extends BaseJsonUrlOptions { //NOPMD
 
                 result
                     .setLocation(litpos)
-                    .addObjectKey(
-                            text,
-                            litpos,
-                            pos,
-                            isEmptyUnquotedKeyAllowed(),
-                            isImpliedStringLiterals());
+                    .addObjectKey(text, litpos, pos);
 
                 pos++;
                 continue;

--- a/module/jsonurl-core/src/main/java/org/jsonurl/ValueFactoryParseResultFacade.java
+++ b/module/jsonurl-core/src/main/java/org/jsonurl/ValueFactoryParseResultFacade.java
@@ -94,17 +94,24 @@ class ValueFactoryParseResultFacade<V,
      * A MissingValueProvider.
      */
     private final MissingValueProvider<V> missingValueProvider;
+    
+    /**
+     * JsonUrlOptions.
+     */
+    private final JsonUrlOptions options;
 
     /**
      * Create a new ValueFactoryParseResultFacade.
      */
     public ValueFactoryParseResultFacade(
             ValueFactory<V,C,ABT,A,JBT,J,B,M,N,S> factory,
+            JsonUrlOptions options,
             ABT impliedArray,
             JBT impliedObject,
             MissingValueProvider<V> missingValueProvider) {
 
         this.factory = factory;
+        this.options = options;
         this.numb = newNumberBuilder(factory);
         this.missingValueProvider = missingValueProvider == null
                 ? this::defaultMissingValueProvier : missingValueProvider;
@@ -162,9 +169,7 @@ class ValueFactoryParseResultFacade<V,
     public void addLiteral(
             CharSequence text,
             int start,
-            int stop,
-            boolean isEmptyUnquotedStringOK,
-            boolean isImpliedStringLiteral) {
+            int stop) {
 
         factoryValueStack.push(
             literal(
@@ -174,17 +179,14 @@ class ValueFactoryParseResultFacade<V,
                     start,
                     stop,
                     factory,
-                    isEmptyUnquotedStringOK,
-                    isImpliedStringLiteral));
+                    options));
     }
 
     @Override
     public void addSingleElementArray(
             CharSequence text,
             int start,
-            int stop,
-            boolean isEmptyUnquotedStringOK,
-            boolean isImpliedStringLiteral) {
+            int stop) {
         ABT sea = factory.newArrayBuilder();
 
         factory.add(
@@ -196,8 +198,7 @@ class ValueFactoryParseResultFacade<V,
                 start,
                 stop,
                 factory,
-                isEmptyUnquotedStringOK,
-                isImpliedStringLiteral));
+                options));
 
         factoryValueStack.push(factory.newArray(sea));                
     }
@@ -206,15 +207,12 @@ class ValueFactoryParseResultFacade<V,
     public void addObjectKey(
             CharSequence text,
             int start,
-            int stop,
-            boolean isEmptyUnquotedStringOK,
-            boolean isImpliedStringLiteral) {
+            int stop) {
         keyStack.push(parseKey(
                 text,
                 start,
                 stop,
-                isEmptyUnquotedStringOK,
-                isImpliedStringLiteral));                
+                options));                
     }
 
     @Override
@@ -254,9 +252,7 @@ class ValueFactoryParseResultFacade<V,
     public V getResult(
             CharSequence text,
             int start,
-            int stop,
-            boolean isEmptyUnquotedStringOK,
-            boolean isImpliedStringLiteral) {
+            int stop) {
 
         return literal(
                 buf,
@@ -265,8 +261,7 @@ class ValueFactoryParseResultFacade<V,
                 start,
                 stop,
                 factory,
-                isEmptyUnquotedStringOK,
-                isImpliedStringLiteral);
+                options);
     }
 
     @Override
@@ -294,8 +289,7 @@ class ValueFactoryParseResultFacade<V,
     public ParseResultFacade<V> addMissingValue(
             CharSequence text,
             int start,
-            int stop,
-            boolean isImpliedStringLiteral) {
+            int stop) {
 
         //
         // note that isEmptyUnquotedStringOK is always false. This makes
@@ -306,8 +300,7 @@ class ValueFactoryParseResultFacade<V,
                 text,
                 start,
                 stop,
-                false,
-                isImpliedStringLiteral);
+                options);
 
         keyStack.push(key);
         factoryValueStack.push(missingValueProvider.getValue(key, position));
@@ -322,8 +315,7 @@ class ValueFactoryParseResultFacade<V,
             CharSequence text,
             int start,
             int stop,
-            boolean isEmptyUnquotedStringOK,
-            boolean isImpliedStringLiteral) {
+            JsonUrlOptions options) {
 
         return literalToJavaString(
                 buf,
@@ -331,8 +323,7 @@ class ValueFactoryParseResultFacade<V,
                 text,
                 start,
                 stop,
-                isEmptyUnquotedStringOK,
-                isImpliedStringLiteral);
+                options);
     }
 
     /**

--- a/module/jsonurl-core/src/test/java/org/jsonurl/AbstractParseTest.java
+++ b/module/jsonurl-core/src/test/java/org/jsonurl/AbstractParseTest.java
@@ -452,7 +452,7 @@ public abstract class AbstractParseTest<
             // test Parser.setImpliedStringLiterals(true)
             //
             Parser p = new Parser();
-            p.setImpliedStringLiterals(true);
+            p.enableImpliedStringLiterals();
 
             assertEquals(
                     getFactoryString(urlDecode(in)),
@@ -466,8 +466,7 @@ public abstract class AbstractParseTest<
                             0,
                             in.length(),
                             factory,
-                            true,
-                            true),
+                            p),
                     in);
         }
 
@@ -490,7 +489,7 @@ public abstract class AbstractParseTest<
             // test Parser.setImpliedStringLiterals(true)
             //
             Parser p = new Parser();
-            p.setImpliedStringLiterals(true);
+            p.enableImpliedStringLiterals();
 
             assertEquals(
                     getFactoryString(text),
@@ -504,8 +503,7 @@ public abstract class AbstractParseTest<
                             0,
                             text.length(),
                             factory,
-                            true,
-                            true),
+                            p),
                     text);
         }
 
@@ -551,6 +549,9 @@ public abstract class AbstractParseTest<
                 Double.valueOf(JsonUrl.parseLiteral(txt, factory).toString()),
                 txt);
 
+            Parser p = new Parser();
+            p.setImpliedStringLiterals(true);
+
             //
             // check implied string literals
             //
@@ -561,12 +562,8 @@ public abstract class AbstractParseTest<
                             0,
                             text.length(),
                             factory,
-                            false,
-                            true),
+                            p),
                     text);
-            
-            Parser p = new Parser();
-            p.setImpliedStringLiterals(true);
 
             assertEquals(
                     getFactoryString(urlDecode(text)),
@@ -587,6 +584,9 @@ public abstract class AbstractParseTest<
             assertEquals(String.valueOf(nativeValue), txt, text);
             assertEquals(factoryValue, JsonUrl.parseLiteral(txt, factory), text);
 
+            Parser p = new Parser();
+            p.setImpliedStringLiterals(true);
+
             assertEquals(
                     getFactoryString(text),
                     JsonUrl.parseLiteral(
@@ -594,16 +594,12 @@ public abstract class AbstractParseTest<
                             0,
                             text.length(),
                             factory,
-                            false,
-                            true),
+                            p),
                     text);
-            
+
             //
             // test Parser.setImpliedStringLiterals(true)
             //
-            Parser p = new Parser();
-            p.setImpliedStringLiterals(true);
-
             assertEquals(
                     getFactoryString(text),
                     p.parse(text, factory),
@@ -646,7 +642,7 @@ public abstract class AbstractParseTest<
 
                 assertThrows(
                     SyntaxException.class,
-                    () -> JsonUrl.parseLiteral(text, 0, text.length(), factory, false, false));
+                    () -> JsonUrl.parseLiteral(text, 0, text.length(), factory, null));
 
             } else {
                 if (factory == JavaValueFactory.PRIMITIVE) {
@@ -656,27 +652,32 @@ public abstract class AbstractParseTest<
      
                 assertEquals(expected, JsonUrl.parseLiteral(text, factory));
                 assertEquals(expected, JsonUrl.parseLiteral(
-                        text, 0, text.length(), factory, false, false));
+                        text, 0, text.length(), factory, null));
             }
+
 
             //
             // test Parser.setEmptyUnquotedValueAllowed(true)
             //
+            Parser p = new Parser();
+            p.setEmptyUnquotedValueAllowed(true);
+
             assertEquals(expected, JsonUrl.parseLiteral(
                     text,
                     0,
                     text.length(),
                     factory,
-                    true,
-                    false));
+                    p));
 
-            Parser p = new Parser();
-            p.setEmptyUnquotedValueAllowed(true);
             assertEquals(expected, p.parse(text, factory));
 
             //
             // test Parser.setImpliedStringLiterals(true);
             //
+            p = new Parser();
+            p.setImpliedStringLiterals(true);
+            p.setEmptyUnquotedValueAllowed(true);
+
             assertEquals(
                     getFactoryString(text),
                     JsonUrl.parseLiteral(
@@ -684,13 +685,9 @@ public abstract class AbstractParseTest<
                             0,
                             text.length(),
                             factory,
-                            true,
-                            true),
+                            p),
                     text);
 
-            p = new Parser();
-            p.setImpliedStringLiterals(true);
-            p.setEmptyUnquotedValueAllowed(true);
             assertEquals(factory.getString(text), p.parse(text, factory));
         }
 
@@ -829,7 +826,7 @@ public abstract class AbstractParseTest<
             // test Parser.setImpliedStringLiterals(true)
             //
             Parser p = new Parser();
-            p.setImpliedStringLiterals(true);
+            p.enableImpliedStringLiterals();
 
             assertEquals(
                     getFactoryString(text),
@@ -843,8 +840,7 @@ public abstract class AbstractParseTest<
                             0,
                             text.length(),
                             factory,
-                            true,
-                            true),
+                            p),
                     text);
         }
 
@@ -961,7 +957,10 @@ public abstract class AbstractParseTest<
                         text);
                 }
             }
-            
+
+            Parser p = new Parser();
+            p.setImpliedStringLiterals(true);
+
             assertEquals(
                     getFactoryString(text),
                     JsonUrl.parseLiteral(
@@ -969,16 +968,12 @@ public abstract class AbstractParseTest<
                             0,
                             text.length(),
                             factory,
-                            false,
-                            true),
+                            p),
                     text);
 
             //
             // test Parser.setImpliedStringLiterals(true)
             //
-            Parser p = new Parser();
-            p.setImpliedStringLiterals(true);
-
             assertEquals(
                     getFactoryString(text),
                     p.parse(text, factory),
@@ -1796,16 +1791,6 @@ public abstract class AbstractParseTest<
             String text,
             Object expect,
             boolean isLiteral) {
-        parse(allow, text, expect, isLiteral, false, false);
-    }
-
-    private void parse(
-            EnumSet<ValueType> allow,
-            String text,
-            Object expect,
-            boolean isLiteral,
-            boolean allowEmptyString,
-            boolean impliedStringLiterals) {
 
         StringBuilder buf = new StringBuilder(1 << 10);
 
@@ -1846,8 +1831,7 @@ public abstract class AbstractParseTest<
                 PREFIX2.length(),
                 text.length(),
                 factory,
-                allowEmptyString,
-                impliedStringLiterals);
+                null);
     
             Object litCompare = expectValue;
             assertEquals(litCompare, litResult, text);


### PR DESCRIPTION
The static methods in org.jsonurl.JsonUrl should follow the same
pattern and accept an instance of the JsonUrl options interface.

Additionally, while it's not visible to code outside the package,
ParseResultFacade has been updated to use them as well.