### PR TITLE
feat: Add support for skip-nulls option to Parser.java

### DIFF
--- a/module/jsonurl-core/src/main/java/org/jsonurl/BaseJsonUrlOptions.java
+++ b/module/jsonurl-core/src/main/java/org/jsonurl/BaseJsonUrlOptions.java
@@ -129,6 +129,7 @@ public class BaseJsonUrlOptions implements JsonUrlOptions {
      * <pre>
      *   setEmptyUnquotedKeyAllowed(true);
      *   setEmptyUnquotedValueAllowed(true);
+     *   setSkipNulls(true);
      *   setImpliedStringLiterals(true);
      * </pre>
      *
@@ -136,11 +137,20 @@ public class BaseJsonUrlOptions implements JsonUrlOptions {
      * {@link #isEmptyUnquotedValueAllowed()} is false then an empty string
      * literal value will trigger an Exception because there wouldn't be any
      * way to represent it.
-     * 
+     *
      * <p>If {@link #isImpliedStringLiterals()} is true but
      * {@link #isEmptyUnquotedKeyAllowed()} is false then an empty key will
      * trigger an Exception because there wouldn't be any way to represent it.
-     * 
+     *
+     * <p>If {@link #isImpliedStringLiterals()} is true but
+     * {@link #isSkipNulls()} is false:<ul>
+     * <li>when writing to a {@link JsonTextBuilder} - a {@code null} will
+     * trigger an Exception because there wouldn't be a way to represent it.
+     * <li>during parse - no exception would occur (because a {@code null}
+     * value isn't possible) but the parse would happen as though
+     * {@code null} values were not present in the stream.
+     * </ul>
+     *
      * <p>If you want the above behavior, because your data doesn't
      * support those cases and you want the parser to catch them for you,
      * then call {@link #setImpliedStringLiterals(boolean)
@@ -153,6 +163,7 @@ public class BaseJsonUrlOptions implements JsonUrlOptions {
     public void enableImpliedStringLiterals() {
         setEmptyUnquotedKeyAllowed(true);
         setEmptyUnquotedValueAllowed(true);
+        setSkipNulls(true);
         setImpliedStringLiterals(true);
     }
 }

--- a/module/jsonurl-core/src/test/java/org/jsonurl/AbstractWriteTest.java
+++ b/module/jsonurl-core/src/test/java/org/jsonurl/AbstractWriteTest.java
@@ -20,6 +20,7 @@ package org.jsonurl;
 import static org.jsonurl.AbstractParseTest.makeImplied;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
@@ -65,6 +66,41 @@ public abstract class AbstractWriteTest<
      * @return a valid ValueFactory instance
      */
     protected abstract ValueFactory<V,C,ABT,A,JBT,J,?,?,?,?> getFactory();
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+        "",
+    })
+    void testEmptyString(String text) throws IOException {
+        String test = "empty string";
+        String expected = "''";
+        JsonUrlStringBuilder jup = new JsonUrlStringBuilder();
+        assertEquals(expected, jup.add(text).build(), test);
+        assertEquals(expected, jup.clear().addKey(text).build(), test);
+
+        jup.setImpliedStringLiterals(true);
+        assertThrows(
+            IOException.class,
+            () -> jup.clear().add(text).build());
+        assertThrows(
+            IOException.class,
+            () -> jup.clear().addKey(text).build());
+        
+        expected = "";
+        jup.setEmptyUnquotedKeyAllowed(true);
+        jup.setEmptyUnquotedValueAllowed(false);
+        assertEquals(expected, jup.addKey(text).build(), test);
+        assertThrows(
+            IOException.class,
+            () -> jup.clear().add(text).build());
+        
+        jup.setEmptyUnquotedKeyAllowed(false);
+        jup.setEmptyUnquotedValueAllowed(true);
+        assertEquals(expected, jup.add(text).build(), test);
+        assertThrows(
+            IOException.class,
+            () -> jup.clear().addKey(text).build());
+    }
 
     @ParameterizedTest
     @ValueSource(strings = {

--- a/module/jsonurl-core/src/test/java/org/jsonurl/j2se/AbstractJavaValueFactoryParseTest.java
+++ b/module/jsonurl-core/src/test/java/org/jsonurl/j2se/AbstractJavaValueFactoryParseTest.java
@@ -63,7 +63,7 @@ abstract class AbstractJavaValueFactoryParseTest extends AbstractParseTest<
     @Override
     protected boolean getNull(String key, Map<String,Object> value) {
         Object ret = value.get(key);
-        return factory.getNull() == ret;
+        return factory.isNull(ret);
     }
 
     @Override
@@ -128,6 +128,11 @@ abstract class AbstractJavaValueFactoryParseTest extends AbstractParseTest<
     @Override
     protected String getStringValue(Object value) {
         return value instanceof String ? (String)value : null;
+    }
+
+    @Override
+    protected int getSize(List<Object> value) {
+        return factory.isNull(value) ? 0 : value.size();
     }
 
     @Override

--- a/module/jsonurl-jsonorg/src/test/java/org/jsonurl/jsonorg/AbstractJsonOrgParseTest.java
+++ b/module/jsonurl-jsonorg/src/test/java/org/jsonurl/jsonorg/AbstractJsonOrgParseTest.java
@@ -104,8 +104,7 @@ abstract class AbstractJsonOrgParseTest extends AbstractParseTest<
     
     @Override
     protected boolean getNull(String key, JSONObject value) {
-        Object ret = value.get(key);
-        return factory.getNull() == ret;
+        return value.isNull(key);
     }
     
     @Override
@@ -126,6 +125,11 @@ abstract class AbstractJsonOrgParseTest extends AbstractParseTest<
     @Override
     protected String getStringValue(Object value) {
         return value instanceof String ? (String)value : null;
+    }
+
+    @Override
+    protected int getSize(JSONArray value) {
+        return factory.isNull(value) ? 0 : value.length();
     }
 
     @Override

--- a/module/jsonurl-jsr374/src/test/java/org/jsonurl/jsonp/AbstractJsonpParseTest.java
+++ b/module/jsonurl-jsr374/src/test/java/org/jsonurl/jsonp/AbstractJsonpParseTest.java
@@ -115,7 +115,7 @@ abstract class AbstractJsonpParseTest extends AbstractParseTest<
     @Override
     protected boolean getNull(String key, JsonObject value) {
         Object ret = value.get(key);
-        return factory.getNull() == ret;
+        return factory.isNull(ret);
     }
     
     @Override
@@ -136,6 +136,11 @@ abstract class AbstractJsonpParseTest extends AbstractParseTest<
     @Override
     protected String getStringValue(JsonValue value) {
         return value instanceof JsonString ? ((JsonString)value).getString() : null;
+    }
+
+    @Override
+    protected int getSize(JsonArray value) {
+        return factory.isNull(value) ? 0 : value.size();
     }
 
     @Override


### PR DESCRIPTION
Parser will now honor JsonUrlOptions.isSkipNulls() and skip null
values during parse so they will not present in the parse result.