### PR TITLE
fix: Remove JsonUrlStringBuilder.add(char) method

### DIFF
--- a/module/jsonurl-core/src/main/java/org/jsonurl/JsonTextBuilder.java
+++ b/module/jsonurl-core/src/main/java/org/jsonurl/JsonTextBuilder.java
@@ -71,6 +71,11 @@ public interface JsonTextBuilder<A,R> {
     JsonTextBuilder<A,R> addNull() throws IOException;
 
     /**
+     * Add a UNICODE codepoint.
+     */
+    JsonTextBuilder<A,R> addCodePoint(int codepoint) throws IOException;
+
+    /**
      * Add a long value.
      */
     JsonTextBuilder<A,R> add(long value) throws IOException;
@@ -94,11 +99,6 @@ public interface JsonTextBuilder<A,R> {
      * Add a boolean value.
      */
     JsonTextBuilder<A,R> add(boolean value) throws IOException;
-
-    /**
-     * Add a boolean value.
-     */
-    JsonTextBuilder<A,R> add(char value) throws IOException;
 
     /**
      * Add a string value.

--- a/module/jsonurl-core/src/main/java/org/jsonurl/JsonUrlTextAppender.java
+++ b/module/jsonurl-core/src/main/java/org/jsonurl/JsonUrlTextAppender.java
@@ -115,6 +115,12 @@ public abstract class JsonUrlTextAppender<A extends Appendable, R> // NOPMD
     }
 
     @Override
+    public JsonUrlTextAppender<A,R> addCodePoint(int codePoint) throws IOException {
+        JsonUrl.appendCodePoint(this, codePoint, this);
+        return this;
+    }
+
+    @Override
     public JsonUrlTextAppender<A,R> add(BigDecimal value) throws IOException {
         if (value == null) {
             return addNull();
@@ -172,12 +178,6 @@ public abstract class JsonUrlTextAppender<A extends Appendable, R> // NOPMD
     @Override
     public JsonUrlTextAppender<A,R> add(boolean value) throws IOException {
         out.append(String.valueOf(value));    
-        return this;
-    }
-
-    @Override
-    public JsonUrlTextAppender<A,R> add(char value) throws IOException {
-        out.append(value);
         return this;
     }
 


### PR DESCRIPTION
The JsonUrlStringBuilder.add(char) was simply appending the given
character to the buffer without proper encoding. It was only used by
JsonUrlWriter.write(char[]), but it's public so it could be used
externally.

The add(char) method was removed and replaced with addCodePoint(int),
which properly handles structural characters and UNICODE.