### PR TITLE
feat!: support full JSON number grammar

### DIFF
--- a/module/jsonurl-core/src/main/java/org/jsonurl/BigMathProvider.java
+++ b/module/jsonurl-core/src/main/java/org/jsonurl/BigMathProvider.java
@@ -115,14 +115,4 @@ public interface BigMathProvider {
      * @return a valid BigIntegerOverflow or null
      */
     BigIntegerOverflow getBigIntegerOverflow();
-
-    /**
-     * Cast the given object to a valid BigMathProvider or {@code null}.  
-     * @param obj any object or {@code null}
-     * @return a valid BigMathProvider or {@code null}
-     */
-    static BigMathProvider forObject(Object obj) {
-        return obj instanceof BigMathProvider
-                ? (BigMathProvider)obj : null;
-    }
 }

--- a/module/jsonurl-core/src/main/java/org/jsonurl/stream/AbstractEventIterator.java
+++ b/module/jsonurl-core/src/main/java/org/jsonurl/stream/AbstractEventIterator.java
@@ -49,6 +49,11 @@ public abstract class AbstractEventIterator
     public static final char WFU_VALUE_SEPARATOR = '&';
 
     /**
+     * x-www-form-urlencoded space (plus).
+     */
+    public static final char WFU_SPACE = '+';
+
+    /**
      * JsonUrlOptions.
      */
     private final Set<JsonUrlOption> options; // NOPMD - final field

--- a/module/jsonurl-core/src/main/java/org/jsonurl/text/JsonUrlTextAppender.java
+++ b/module/jsonurl-core/src/main/java/org/jsonurl/text/JsonUrlTextAppender.java
@@ -444,6 +444,11 @@ public abstract class JsonUrlTextAppender<A extends Appendable, R> // NOPMD
         }
 
         if (optionImpliedStringLiterals(options)) {
+            if (optionAQF(options)) {
+                encodeAqf(dest, text, start, end);
+                return true;
+            }
+
             encode(dest, text, start, end, false, true);
             return true;
         }

--- a/module/jsonurl-core/src/main/java/org/jsonurl/text/NumberBuilder.java
+++ b/module/jsonurl-core/src/main/java/org/jsonurl/text/NumberBuilder.java
@@ -19,7 +19,6 @@ package org.jsonurl.text;
 
 import static org.jsonurl.BigMathProvider.NEGATIVE_INFINITY;
 import static org.jsonurl.BigMathProvider.POSITIVE_INFINITY;
-import static org.jsonurl.JsonUrlOption.optionAQF;
 import static org.jsonurl.LimitException.Message.MSG_LIMIT_INTEGER;
 
 import java.math.BigDecimal;
@@ -383,8 +382,7 @@ public class NumberBuilder implements NumberText { // NOPMD
     private static NumberText.Exponent getExponentType(//NOPMD
             CharSequence text,
             int start,
-            int stop,
-            Set<JsonUrlOption> options) {
+            int stop) {
 
         if (stop <= start) {
             return NumberText.Exponent.NONE;
@@ -410,7 +408,7 @@ public class NumberBuilder implements NumberText { // NOPMD
         switch (c) {
         case PLUS:
             i++;
-            if (i == stop || optionAQF(options)) {
+            if (i == stop) {
                 return NumberText.Exponent.NONE;
             }
             c = text.charAt(i);
@@ -517,7 +515,7 @@ public class NumberBuilder implements NumberText { // NOPMD
             fractIndexStop = pos = digits(text, pos + 1, stop);
         }
 
-        exponentType = getExponentType(text, pos, stop, options);
+        exponentType = getExponentType(text, pos, stop);
 
         switch (exponentType) { // NOPMD - SwitchStmtsShouldHaveDefault
         case JUST_VALUE:
@@ -663,7 +661,7 @@ public class NumberBuilder implements NumberText { // NOPMD
 
         final int expDigitSkip;
 
-        switch (getExponentType(text, pos, stop, options)) {
+        switch (getExponentType(text, pos, stop)) {
         case JUST_VALUE:
             expDigitSkip = 1;
             pos = digits(text, pos + 1, stop);

--- a/module/jsonurl-core/src/test/java/org/jsonurl/stream/JsonUrlIteratorTest.java
+++ b/module/jsonurl-core/src/test/java/org/jsonurl/stream/JsonUrlIteratorTest.java
@@ -251,10 +251,22 @@ class JsonUrlIteratorTest {
         return Stream.concat(COMMON_TESTS.parallelStream(),
             Arrays.stream(new EventTest[] {
                 new EventTest(
-                    "1e+2",
+                    "1e!+2",
                     new Object[] {
                         JsonUrlEvent.VALUE_STRING,
-                        "1e 2",
+                        "1e+2",
+                        JsonUrlEvent.END_STREAM}),
+                new EventTest(
+                    "1e%2B1",
+                    new Object[] {
+                        JsonUrlEvent.VALUE_NUMBER,
+                        "1e+1",
+                        JsonUrlEvent.END_STREAM}),
+                new EventTest(
+                    "1e!-2",
+                    new Object[] {
+                        JsonUrlEvent.VALUE_STRING,
+                        "1e-2",
                         JsonUrlEvent.END_STREAM}),
                 new EventTest(
                     "('')",
@@ -305,6 +317,11 @@ class JsonUrlIteratorTest {
                     new Object[] {
                         JsonUrlEvent.VALUE_EMPTY_LITERAL,
                         JsonUrlEvent.END_STREAM}),
+
+                new EventTest(
+                        "!e!e",
+                        SyntaxException.class),
+
                 new EventTest(
                     "!3",
                     new Object[] {
@@ -324,6 +341,12 @@ class JsonUrlIteratorTest {
                         "a b",
                         JsonUrlEvent.END_STREAM}),
                 new EventTest(
+                    "a%2Bb",
+                    new Object[] {
+                        JsonUrlEvent.VALUE_STRING,
+                        "a+b",
+                        JsonUrlEvent.END_STREAM}),
+                new EventTest(
                     "(!e:a)",
                     new Object[] {
                         JsonUrlEvent.START_OBJECT,
@@ -334,8 +357,22 @@ class JsonUrlIteratorTest {
                         JsonUrlEvent.END_OBJECT,
                         JsonUrlEvent.END_STREAM}),
                 new EventTest(
-                    "!e!e",
-                    SyntaxException.class),
+                    "%21e",
+                    new Object[] {
+                        JsonUrlEvent.VALUE_EMPTY_LITERAL,
+                        JsonUrlEvent.END_STREAM}),
+                new EventTest(
+                    "%21%65",
+                    new Object[] {
+                        JsonUrlEvent.VALUE_EMPTY_LITERAL,
+                        JsonUrlEvent.END_STREAM}),
+                new EventTest(
+                    "%21+",
+                    new Object[] {
+                        JsonUrlEvent.VALUE_STRING,
+                        "+",
+                        JsonUrlEvent.END_STREAM}),
+
             }));
     }
 
@@ -361,10 +398,22 @@ class JsonUrlIteratorTest {
         return Stream.concat(COMMON_TESTS.parallelStream(),
             Arrays.stream(new EventTest[] {
                 new EventTest(
-                    "1e+2",
+                    "1e!+2",
                     new Object[] {
-                        JsonUrlEvent.VALUE_NUMBER,
-                        "1e+2",
+                        JsonUrlEvent.VALUE_STRING,
+                        "1e! 2",
+                        JsonUrlEvent.END_STREAM}),
+                new EventTest(
+                    "1e%2B1",
+                    new Object[] {
+                        JsonUrlEvent.VALUE_STRING,
+                        "1e+1",
+                        JsonUrlEvent.END_STREAM}),
+                new EventTest(
+                    "1e!-2",
+                    new Object[] {
+                        JsonUrlEvent.VALUE_STRING,
+                        "1e!-2",
                         JsonUrlEvent.END_STREAM}),
                 new EventTest(
                     "('')",
@@ -416,6 +465,13 @@ class JsonUrlIteratorTest {
                         JsonUrlEvent.END_STREAM}),
 
                 new EventTest(
+                    "!e!e",
+                    new Object[] {
+                        JsonUrlEvent.VALUE_STRING,
+                        "!e!e",
+                        JsonUrlEvent.END_STREAM}),
+
+                new EventTest(
                     "!3",
                     new Object[] {
                         JsonUrlEvent.VALUE_STRING,
@@ -441,6 +497,13 @@ class JsonUrlIteratorTest {
                         JsonUrlEvent.END_STREAM}),
 
                 new EventTest(
+                        "a%2Bb",
+                        new Object[] {
+                            JsonUrlEvent.VALUE_STRING,
+                            "a+b",
+                            JsonUrlEvent.END_STREAM}),
+
+                new EventTest(
                     "(!e:a)",
                     new Object[] {
                         JsonUrlEvent.START_OBJECT,
@@ -452,10 +515,23 @@ class JsonUrlIteratorTest {
                         JsonUrlEvent.END_STREAM}),
 
                 new EventTest(
-                    "!e!e",
+                    "%21e",
                     new Object[] {
                         JsonUrlEvent.VALUE_STRING,
-                        "!e!e",
+                        "!e",
+                        JsonUrlEvent.END_STREAM}),
+                new EventTest(
+                    "%21%65",
+                    new Object[] {
+                        JsonUrlEvent.VALUE_STRING,
+                        "!e",
+                        JsonUrlEvent.END_STREAM}),
+
+                new EventTest(
+                    "%21+",
+                    new Object[] {
+                        JsonUrlEvent.VALUE_STRING,
+                        "! ",
                         JsonUrlEvent.END_STREAM}),
 
             }));
@@ -539,6 +615,34 @@ class JsonUrlIteratorTest {
                     JsonUrlEvent.VALUE_NUMBER,
                     "1e-2",
                     JsonUrlEvent.END_STREAM}),
+            new EventTest(
+                "1e+2",
+                new Object[] {
+                    JsonUrlEvent.VALUE_NUMBER,
+                    "1e+2",
+                    JsonUrlEvent.END_STREAM}),
+            new EventTest(
+                "1e+2",
+                new Object[] {
+                    JsonUrlEvent.VALUE_NUMBER,
+                    "1e+2",
+                    JsonUrlEvent.END_STREAM}),
+
+            new EventTest(
+                JsonUrlOption.IMPLIED_STRING_LITERALS,
+                "1e%2B1",
+                new Object[] {
+                    JsonUrlEvent.VALUE_STRING,
+                    "1e+1",
+                    JsonUrlEvent.END_STREAM}),
+
+            new EventTest(
+                    JsonUrlOption.IMPLIED_STRING_LITERALS,
+                    "1e+2",
+                    new Object[] {
+                        JsonUrlEvent.VALUE_STRING,
+                        "1e 2",
+                        JsonUrlEvent.END_STREAM}),
 
             new EventTest(
                 JsonUrlOption.EMPTY_UNQUOTED_VALUE,

--- a/module/jsonurl-core/src/test/java/org/jsonurl/text/JsonUrlStringBuilderTest.java
+++ b/module/jsonurl-core/src/test/java/org/jsonurl/text/JsonUrlStringBuilderTest.java
@@ -524,10 +524,10 @@ class JsonUrlStringBuilderTest {
         //     be encoded so that it doesn't look like a number
         // expectedISL - Plus needs to be encoded so it isn't decoded as a
         //     space
-        // expectedAqf - this is NOT a valid literal in the AQF syntax so
-        //     the plus is simply escaped.
+        // expectedAqf - this is a valid literal in the AQF syntax so
+        //     the first character must be escaped.
         //
-        "1e+3,1e%2B3,1e%2B3,1e!+3",
+        "1e+3,1e%2B3,1e%2B3,!1e+3",
     })
     void testEncodedString(
             String text,


### PR DESCRIPTION
The initial revision of AQF did not support numbers with exponents
prefixed with a plus. This commit allows for that, and so the full
number production is supported.