### PR TITLE
fix: Fix wfu bug

### DIFF
--- a/module/jsonurl-core/src/main/java/org/jsonurl/SyntaxException.java
+++ b/module/jsonurl-core/src/main/java/org/jsonurl/SyntaxException.java
@@ -53,6 +53,8 @@ public class SyntaxException extends ParseException {
         MSG_EXPECT_OBJECT_KEY("expected object key"),
         /** Expected object value. */
         MSG_EXPECT_OBJECT_VALUE("expected object value"),
+        /** Expected structural character. */
+        MSG_EXPECT_PAREN("expected open paren"),
         /** Unexpected array. */
         MSG_UNEXPECTED_ARRAY("unexpected array"),
         /** Unexpected boolean. */

--- a/module/jsonurl-core/src/main/java/org/jsonurl/stream/AbstractCharIterator.java
+++ b/module/jsonurl-core/src/main/java/org/jsonurl/stream/AbstractCharIterator.java
@@ -150,7 +150,6 @@ public abstract class AbstractCharIterator implements CharIterator {
 
     /**
      * Read a single character and update the current position information.
-     * @return
      */
     private int readUpdatePosition() throws IOException {
         int ret = read();

--- a/module/jsonurl-core/src/main/java/org/jsonurl/stream/AbstractEventIterator.java
+++ b/module/jsonurl-core/src/main/java/org/jsonurl/stream/AbstractEventIterator.java
@@ -54,6 +54,11 @@ public abstract class AbstractEventIterator
     public static final char WFU_SPACE = '+';
 
     /**
+     * Percent character {@code (%)}.
+     */
+    public static final char PERCENT = '%';
+
+    /**
      * JsonUrlOptions.
      */
     private final Set<JsonUrlOption> options; // NOPMD - final field

--- a/module/jsonurl-core/src/main/java/org/jsonurl/stream/JsonUrlGrammar.java
+++ b/module/jsonurl-core/src/main/java/org/jsonurl/stream/JsonUrlGrammar.java
@@ -254,8 +254,7 @@ class JsonUrlGrammar extends AbstractGrammar {
         return literalText.toString();
     }
 
-    @Override
-    protected int nextChar() {
+    private int nextChar() {
         try {
             return text.nextChar();
 
@@ -266,8 +265,7 @@ class JsonUrlGrammar extends AbstractGrammar {
         }
     }
 
-    @Override
-    protected int peekChar() {
+    private int peekChar() {
         try {
             return text.peekChar();
 
@@ -276,6 +274,25 @@ class JsonUrlGrammar extends AbstractGrammar {
             tex.initCause(e);
             throw tex;
         }
+    }
+
+    @Override
+    protected int nextStructChar(boolean peek) {
+        int cur = peek ? peekChar() : nextChar();
+
+        if (cur == EOF) {
+            return EOF;
+        }
+
+        if (cur >= CharUtil.CHARBITS_LENGTH) {
+            throw newSyntaxException(MSG_BAD_CHAR);
+        }
+
+        if ((CHARBITS[cur] & IS_STRUCTCHAR) == IS_STRUCTCHAR) {
+            return cur;
+        }
+
+        return 0;
     }
 
     /**

--- a/module/jsonurl-core/src/main/java/org/jsonurl/stream/JsonUrlGrammarAQF.java
+++ b/module/jsonurl-core/src/main/java/org/jsonurl/stream/JsonUrlGrammarAQF.java
@@ -281,6 +281,7 @@ class JsonUrlGrammarAQF extends AbstractGrammar {
     }
 
     @Override
+    @SuppressWarnings("PMD.CyclomaticComplexity")
     protected int nextStructChar(boolean peek) {
         int ret = nextChar == EOF ? peekAscii() : nextChar;
         

--- a/module/jsonurl-core/src/test/java/org/jsonurl/stream/JsonUrlIteratorTest.java
+++ b/module/jsonurl-core/src/test/java/org/jsonurl/stream/JsonUrlIteratorTest.java
@@ -89,7 +89,7 @@ class JsonUrlIteratorTest {
         final Class<? extends Exception> exceptionClass;
 
         EventTest(String text, Object... expected) {
-            this(null, null, text, expected);
+            this((Set<JsonUrlOption>)null, null, text, expected);
         }
 
         EventTest(Set<JsonUrlOption> options,
@@ -102,6 +102,13 @@ class JsonUrlIteratorTest {
                 String text,
                 Object... expected) {
             this(EnumSet.of(option), text, expected);
+        }
+
+        EventTest(JsonUrlOption option,
+                CompositeType impliedType,
+                String text,
+                Object... expected) {
+            this(EnumSet.of(option), impliedType, text, expected);
         }
 
         @SuppressWarnings("PMD.ArrayIsStoredDirectly")
@@ -637,18 +644,32 @@ class JsonUrlIteratorTest {
                     JsonUrlEvent.END_STREAM}),
 
             new EventTest(
-                    JsonUrlOption.IMPLIED_STRING_LITERALS,
-                    "1e+2",
-                    new Object[] {
-                        JsonUrlEvent.VALUE_STRING,
-                        "1e 2",
-                        JsonUrlEvent.END_STREAM}),
+                JsonUrlOption.IMPLIED_STRING_LITERALS,
+                "1e+2",
+                new Object[] {
+                    JsonUrlEvent.VALUE_STRING,
+                    "1e 2",
+                    JsonUrlEvent.END_STREAM}),
 
             new EventTest(
                 JsonUrlOption.EMPTY_UNQUOTED_VALUE,
                 EMPTY_STRING,
                 new Object[] {
                     JsonUrlEvent.VALUE_EMPTY_LITERAL,
+                    JsonUrlEvent.END_STREAM}),
+
+            new EventTest(
+                "true%26",
+                new Object[] {
+                    JsonUrlEvent.VALUE_STRING,
+                    "true&",
+                    JsonUrlEvent.END_STREAM}),
+
+            new EventTest(
+                "%26true",
+                new Object[] {
+                    JsonUrlEvent.VALUE_STRING,
+                    "&true",
                     JsonUrlEvent.END_STREAM}),
 
             // Array
@@ -771,6 +792,57 @@ class JsonUrlIteratorTest {
                 "",
                 new Object[] {JsonUrlEvent.END_STREAM}),
 
+            new EventTest(
+                "(%26true)",
+                new Object[] {
+                    JsonUrlEvent.START_ARRAY,
+                    JsonUrlEvent.VALUE_STRING,
+                    "&true",
+                    JsonUrlEvent.END_ARRAY,
+                    JsonUrlEvent.END_STREAM}),
+
+            new EventTest(
+                EnumSet.of(JsonUrlOption.WFU_COMPOSITE, JsonUrlOption.EMPTY_UNQUOTED_VALUE),
+                "(&true)",
+                new Object[] {
+                    JsonUrlEvent.START_ARRAY,
+                    JsonUrlEvent.VALUE_EMPTY_LITERAL,
+                    JsonUrlEvent.VALUE_TRUE,
+                    JsonUrlEvent.END_ARRAY,
+                    JsonUrlEvent.END_STREAM}),
+
+            new EventTest(
+                "(true%26true)",
+                new Object[] {
+                    JsonUrlEvent.START_ARRAY,
+                    JsonUrlEvent.VALUE_STRING,
+                    "true&true",
+                    JsonUrlEvent.END_ARRAY,
+                    JsonUrlEvent.END_STREAM}),
+
+            new EventTest(
+                EnumSet.of(JsonUrlOption.WFU_COMPOSITE, JsonUrlOption.IMPLIED_STRING_LITERALS),
+                "(true&true)",
+                new Object[] {
+                    JsonUrlEvent.START_ARRAY,
+                    JsonUrlEvent.VALUE_STRING,
+                    "true",
+                    JsonUrlEvent.VALUE_STRING,
+                    "true",
+                    JsonUrlEvent.END_ARRAY,
+                    JsonUrlEvent.END_STREAM}),
+
+            new EventTest(
+                "((%26true))",
+                new Object[] {
+                    JsonUrlEvent.START_ARRAY,
+                    JsonUrlEvent.START_ARRAY,
+                    JsonUrlEvent.VALUE_STRING,
+                    "&true",
+                    JsonUrlEvent.END_ARRAY,
+                    JsonUrlEvent.END_ARRAY,
+                    JsonUrlEvent.END_STREAM}),
+
             // Object
             new EventTest(
                 JsonUrlOption.EMPTY_UNQUOTED_KEY,
@@ -810,7 +882,7 @@ class JsonUrlIteratorTest {
                     JsonUrlEvent.END_OBJECT,
                     JsonUrlEvent.END_STREAM}),
             new EventTest(
-                EnumSet.of(JsonUrlOption.WFU_COMPOSITE),
+                JsonUrlOption.WFU_COMPOSITE,
                 CompositeType.OBJECT,
                 "a=b",
                 new Object[] {
@@ -820,7 +892,7 @@ class JsonUrlIteratorTest {
                     "b",
                     JsonUrlEvent.END_STREAM}),
             new EventTest(
-                EnumSet.of(JsonUrlOption.WFU_COMPOSITE),
+                JsonUrlOption.WFU_COMPOSITE,
                 CompositeType.OBJECT,
                 "a=b&c=d",
                 new Object[] {
@@ -834,7 +906,7 @@ class JsonUrlIteratorTest {
                     "d",
                     JsonUrlEvent.END_STREAM}),
             new EventTest(
-                EnumSet.of(JsonUrlOption.EMPTY_UNQUOTED_VALUE),
+                JsonUrlOption.EMPTY_UNQUOTED_VALUE,
                 CompositeType.OBJECT,
                 "a:",
                 new Object[] {
@@ -843,7 +915,7 @@ class JsonUrlIteratorTest {
                     JsonUrlEvent.VALUE_EMPTY_LITERAL,
                     JsonUrlEvent.END_STREAM}),
             new EventTest(
-                EnumSet.of(JsonUrlOption.EMPTY_UNQUOTED_KEY),
+                JsonUrlOption.EMPTY_UNQUOTED_KEY,
                 CompositeType.OBJECT,
                 ":b",
                 new Object[] {
@@ -853,7 +925,7 @@ class JsonUrlIteratorTest {
                     "b",
                     JsonUrlEvent.END_STREAM}),
             new EventTest(
-                EnumSet.of(JsonUrlOption.WFU_COMPOSITE),
+                JsonUrlOption.WFU_COMPOSITE,
                 CompositeType.OBJECT,
                 "a&c=d",
                 new Object[] {
@@ -866,7 +938,7 @@ class JsonUrlIteratorTest {
                     "d",
                     JsonUrlEvent.END_STREAM}),
             new EventTest(
-                EnumSet.of(JsonUrlOption.WFU_COMPOSITE),
+                JsonUrlOption.WFU_COMPOSITE,
                 CompositeType.OBJECT,
                 "a=b&c",
                 new Object[] {
@@ -879,12 +951,12 @@ class JsonUrlIteratorTest {
                     JsonUrlEvent.VALUE_MISSING,
                     JsonUrlEvent.END_STREAM}),
             new EventTest(
-                EnumSet.of(JsonUrlOption.WFU_COMPOSITE),
+                JsonUrlOption.WFU_COMPOSITE,
                 CompositeType.OBJECT,
                 EMPTY_STRING,
                 new Object[] {JsonUrlEvent.END_STREAM}),
             new EventTest(
-                EnumSet.of(JsonUrlOption.WFU_COMPOSITE),
+                JsonUrlOption.WFU_COMPOSITE,
                 CompositeType.OBJECT,
                 "a=(c:d)",
                 new Object[] {
@@ -898,7 +970,7 @@ class JsonUrlIteratorTest {
                     JsonUrlEvent.END_OBJECT,
                     JsonUrlEvent.END_STREAM}),
             new EventTest(
-                EnumSet.of(JsonUrlOption.WFU_COMPOSITE),
+                JsonUrlOption.WFU_COMPOSITE,
                 CompositeType.OBJECT,
                 "a=(b:(c:d))",
                 new Object[] {
@@ -916,7 +988,7 @@ class JsonUrlIteratorTest {
                     JsonUrlEvent.END_OBJECT,
                     JsonUrlEvent.END_STREAM}),
             new EventTest(
-                EnumSet.of(JsonUrlOption.WFU_COMPOSITE),
+                JsonUrlOption.WFU_COMPOSITE,
                 CompositeType.ARRAY,
                 "a&(b,(c,(d)))",
                 new Object[] {
@@ -982,6 +1054,29 @@ class JsonUrlIteratorTest {
                     "a",
                     JsonUrlEvent.VALUE_STRING,
                     "ABCDEFGHIJKLMNOP",
+                    JsonUrlEvent.END_OBJECT,
+                    JsonUrlEvent.END_STREAM}),
+
+            new EventTest(
+                "(a:%26true)",
+                new Object[] {
+                    JsonUrlEvent.START_OBJECT,
+                    JsonUrlEvent.KEY_NAME,
+                    "a",
+                    JsonUrlEvent.VALUE_STRING,
+                    "&true",
+                    JsonUrlEvent.END_OBJECT,
+                    JsonUrlEvent.END_STREAM}),
+
+            new EventTest(
+                JsonUrlOption.WFU_COMPOSITE,
+                "(a:%26true)",
+                new Object[] {
+                    JsonUrlEvent.START_OBJECT,
+                    JsonUrlEvent.KEY_NAME,
+                    "a",
+                    JsonUrlEvent.VALUE_STRING,
+                    "&true",
                     JsonUrlEvent.END_OBJECT,
                     JsonUrlEvent.END_STREAM}),
 


### PR DESCRIPTION
When the first character of a literal began with a percent encoded
ampersand the parser improperly interpreted it literally (as a
structural character).
