### PR TITLE
feature: Add JsonUrlOption.NO_EMPTY_COMPOSITE

### DIFF
--- a/module/jsonurl-core/src/main/java/org/jsonurl/JsonUrlOption.java
+++ b/module/jsonurl-core/src/main/java/org/jsonurl/JsonUrlOption.java
@@ -80,7 +80,23 @@ public enum JsonUrlOption {
     /**
      * Address bar query string friendly.
      */
-    AQF;
+    AQF,
+    
+    /**
+     * Distinguish between an empty object and empty array, and never
+     * recognize the empty composite.
+     *
+     * <p>Empty array is back-to-back parens, i.e. {@code ()}. Empty object
+     * is two parens with a single colon inside, i.e. {@code (:)}. Note that
+     * this prevents the parser from recognizing {@code (:)} as an object with
+     * a single member whose key and value is the unquoted empty string when
+     * {@link #EMPTY_UNQUOTED_KEY} and {@link #EMPTY_UNQUOTED_VALUE} are also
+     * both enabled.
+     *
+     * @see <a href="https://github.com/jsonurl/specification#295-empty-objects-and-arrays"
+     * >JSON&#x2192;URL specification, section 2.9.5</a>
+     */
+    NO_EMPTY_COMPOSITE;
 
     /**
      * Create an empty set of options. This is just a convenience wrapper
@@ -234,4 +250,26 @@ public enum JsonUrlOption {
         return options != null && options.contains(AQF);
     }
 
+    /**
+     * Test if the {@link #NO_EMPTY_COMPOSITE} option is enabled,
+     * supplying the default value if necessary.
+     * @param options a valid Set or {@code null}.
+     */
+    public static final boolean optionNoEmptyComposite(
+            Set<JsonUrlOption> options) {
+        return options != null && options.contains(NO_EMPTY_COMPOSITE);
+    }
+
+    /**
+     * Test if the given options could result in ambigous input/output.
+     * @param options a valid Set or {@code null}
+     */
+    public static final boolean isAmbiguous(
+            Set<JsonUrlOption> options) {
+
+        return options != null
+            && options.contains(NO_EMPTY_COMPOSITE)
+            && options.contains(EMPTY_UNQUOTED_KEY)
+            && options.contains(EMPTY_UNQUOTED_VALUE);
+    }
 }

--- a/module/jsonurl-core/src/main/java/org/jsonurl/stream/JsonUrlGrammar.java
+++ b/module/jsonurl-core/src/main/java/org/jsonurl/stream/JsonUrlGrammar.java
@@ -231,6 +231,13 @@ class JsonUrlGrammar extends AbstractGrammar {
     }
 
     @Override
+    protected boolean isEmptyBufferedLiteral(boolean flag) {
+        return flag
+            ? this.decodedTextBuffer.length() == 0
+            : this.rawTextBuffer.length() == 0;
+    }
+
+    @Override
     protected JsonUrlEvent readLiteral(boolean isKey) {
         final int cval = nextChar();
 

--- a/module/jsonurl-core/src/main/java/org/jsonurl/stream/JsonUrlGrammarAQF.java
+++ b/module/jsonurl-core/src/main/java/org/jsonurl/stream/JsonUrlGrammarAQF.java
@@ -271,6 +271,11 @@ class JsonUrlGrammarAQF extends AbstractGrammar {
     }
 
     @Override
+    protected boolean isEmptyBufferedLiteral(boolean flag) {
+        return decodedTextBuffer.length() == 0;
+    }
+
+    @Override
     protected JsonUrlEvent readLiteral(boolean isKey) {
         return readBufferedLiteral(readAndBufferLiteral(), isKey);
     }

--- a/module/jsonurl-core/src/test/java/org/jsonurl/stream/JsonUrlIteratorTest.java
+++ b/module/jsonurl-core/src/test/java/org/jsonurl/stream/JsonUrlIteratorTest.java
@@ -380,6 +380,26 @@ class JsonUrlIteratorTest {
                         "+",
                         JsonUrlEvent.END_STREAM}),
 
+                new EventTest(
+                    "%28hello%29",
+                    new Object[] {
+                        JsonUrlEvent.START_ARRAY,
+                        JsonUrlEvent.VALUE_STRING,
+                        "hello",
+                        JsonUrlEvent.END_ARRAY,
+                        JsonUrlEvent.END_STREAM}),
+
+                new EventTest(
+                    "%28hello",
+                    SyntaxException.class),
+
+                new EventTest(
+                    "%21%28hello!%29",
+                    new Object[] {
+                        JsonUrlEvent.VALUE_STRING,
+                        "(hello)",
+                        JsonUrlEvent.END_STREAM}),
+
             }));
     }
 
@@ -539,6 +559,27 @@ class JsonUrlIteratorTest {
                     new Object[] {
                         JsonUrlEvent.VALUE_STRING,
                         "! ",
+                        JsonUrlEvent.END_STREAM}),
+
+                new EventTest(
+                    "%28hello%29",
+                    new Object[] {
+                        JsonUrlEvent.VALUE_STRING,
+                        "(hello)",
+                        JsonUrlEvent.END_STREAM}),
+
+                new EventTest(
+                    "%28hello",
+                    new Object[] {
+                        JsonUrlEvent.VALUE_STRING,
+                        "(hello",
+                        JsonUrlEvent.END_STREAM}),
+
+                new EventTest(
+                    "%21%28hello!%29",
+                    new Object[] {
+                        JsonUrlEvent.VALUE_STRING,
+                        "!(hello!)",
                         JsonUrlEvent.END_STREAM}),
 
             }));
@@ -843,6 +884,34 @@ class JsonUrlIteratorTest {
                     JsonUrlEvent.END_ARRAY,
                     JsonUrlEvent.END_STREAM}),
 
+            new EventTest(
+                JsonUrlOption.NO_EMPTY_COMPOSITE,
+                "()",
+                new Object[] {
+                    JsonUrlEvent.START_ARRAY,
+                    JsonUrlEvent.END_ARRAY,
+                    JsonUrlEvent.END_STREAM}),
+            new EventTest(
+                JsonUrlOption.NO_EMPTY_COMPOSITE,
+                "(())",
+                new Object[] {
+                    JsonUrlEvent.START_ARRAY,
+                    JsonUrlEvent.START_ARRAY,
+                    JsonUrlEvent.END_ARRAY,
+                    JsonUrlEvent.END_ARRAY,
+                    JsonUrlEvent.END_STREAM}),
+            new EventTest(
+                JsonUrlOption.NO_EMPTY_COMPOSITE,
+                "((()))",
+                new Object[] {
+                    JsonUrlEvent.START_ARRAY,
+                    JsonUrlEvent.START_ARRAY,
+                    JsonUrlEvent.START_ARRAY,
+                    JsonUrlEvent.END_ARRAY,
+                    JsonUrlEvent.END_ARRAY,
+                    JsonUrlEvent.END_ARRAY,
+                    JsonUrlEvent.END_STREAM}),
+
             // Object
             new EventTest(
                 JsonUrlOption.EMPTY_UNQUOTED_KEY,
@@ -914,6 +983,7 @@ class JsonUrlIteratorTest {
                     "a",
                     JsonUrlEvent.VALUE_EMPTY_LITERAL,
                     JsonUrlEvent.END_STREAM}),
+
             new EventTest(
                 JsonUrlOption.EMPTY_UNQUOTED_KEY,
                 CompositeType.OBJECT,
@@ -924,6 +994,17 @@ class JsonUrlIteratorTest {
                     JsonUrlEvent.VALUE_STRING,
                     "b",
                     JsonUrlEvent.END_STREAM}),
+
+            new EventTest(
+                JsonUrlOption.EMPTY_UNQUOTED_VALUE,
+                CompositeType.OBJECT,
+                "a",
+                new Object[] {
+                    JsonUrlEvent.KEY_NAME,
+                    "a",
+                    JsonUrlEvent.VALUE_MISSING,
+                    JsonUrlEvent.END_STREAM}),
+
             new EventTest(
                 JsonUrlOption.WFU_COMPOSITE,
                 CompositeType.OBJECT,
@@ -1080,9 +1161,66 @@ class JsonUrlIteratorTest {
                     JsonUrlEvent.END_OBJECT,
                     JsonUrlEvent.END_STREAM}),
 
+            new EventTest(
+                EnumSet.of(JsonUrlOption.EMPTY_UNQUOTED_KEY, JsonUrlOption.EMPTY_UNQUOTED_VALUE),
+                "(:)",
+                new Object[] {
+                    JsonUrlEvent.START_OBJECT,
+                    JsonUrlEvent.KEY_NAME,
+                    EMPTY_STRING,
+                    JsonUrlEvent.VALUE_EMPTY_LITERAL,
+                    JsonUrlEvent.END_OBJECT,
+                    JsonUrlEvent.END_STREAM}),
+
+            new EventTest(
+                EnumSet.of(JsonUrlOption.EMPTY_UNQUOTED_KEY, JsonUrlOption.EMPTY_UNQUOTED_VALUE),
+                CompositeType.OBJECT,
+                ":",
+                new Object[] {
+                    JsonUrlEvent.KEY_NAME,
+                    EMPTY_STRING,
+                    JsonUrlEvent.VALUE_EMPTY_LITERAL,
+                    JsonUrlEvent.END_STREAM}),
+
+            new EventTest(
+                JsonUrlOption.NO_EMPTY_COMPOSITE,
+                "(:)",
+                new Object[] {
+                    JsonUrlEvent.START_OBJECT,
+                    JsonUrlEvent.END_OBJECT,
+                    JsonUrlEvent.END_STREAM}),
+
+            new EventTest(
+                JsonUrlOption.NO_EMPTY_COMPOSITE,
+                "(a:(:))",
+                new Object[] {
+                    JsonUrlEvent.START_OBJECT,
+                    JsonUrlEvent.KEY_NAME,
+                    "a",
+                    JsonUrlEvent.START_OBJECT,
+                    JsonUrlEvent.END_OBJECT,
+                    JsonUrlEvent.END_OBJECT,
+                    JsonUrlEvent.END_STREAM}),
+
+            new EventTest(
+                JsonUrlOption.NO_EMPTY_COMPOSITE,
+                CompositeType.OBJECT,
+                "a:(:)",
+                new Object[] {
+                    JsonUrlEvent.KEY_NAME,
+                    "a",
+                    JsonUrlEvent.START_OBJECT,
+                    JsonUrlEvent.END_OBJECT,
+                    JsonUrlEvent.END_STREAM}),
+
+
             // Exception
             new EventTest(
                 EMPTY_STRING,
+                SyntaxException.class),
+
+            new EventTest(
+                "¶",
                 SyntaxException.class),
 
             new EventTest(
@@ -1132,7 +1270,15 @@ class JsonUrlIteratorTest {
                 LimitException.class),
 
             new EventTest(
+                "(hello:)",
+                SyntaxException.class),
+
+            new EventTest(
                 "(:world)",
+                SyntaxException.class),
+
+            new EventTest(
+                "(:)",
                 SyntaxException.class),
 
             new EventTest(

--- a/module/jsonurl-core/src/test/java/org/jsonurl/text/JsonUrlStringBuilderTest.java
+++ b/module/jsonurl-core/src/test/java/org/jsonurl/text/JsonUrlStringBuilderTest.java
@@ -129,7 +129,7 @@ class JsonUrlStringBuilderTest {
         'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm',
         'n', 'o', 'p', 'q', 'r', 's', 't', 'u', 'v', 'w', 'x', 'y', 'z',
         '0', '1', '2', '3', '4', '5', '6', '7', '8', '9',
-        '!', '-', '.', '_', '~', '!', '$', '*', '/', ';', '?', '@',
+        '!', '-', '.', '_', '~', '$', '*', '/', ';', '?', '@',
     })
     void testAddCodePointLiteral(char codePoint) throws IOException {
         String expected = String.valueOf(codePoint);
@@ -139,7 +139,7 @@ class JsonUrlStringBuilderTest {
 
         assertEquals(expected, actual, expected);
     }
-    
+
     @ParameterizedTest
     @ValueSource(chars = {
         '+', '\'', '(', ')', ',', ':'
@@ -151,6 +151,41 @@ class JsonUrlStringBuilderTest {
         assertCodePoint(expected, codePoint);
     }
 
+    @Test
+    void testEmptyObject() throws IOException {
+        final String testName = "empty object";
+
+        assertEquals(
+            "()",
+            new JsonUrlStringBuilder().beginObject().endObject().build(),
+            testName);
+
+        assertEquals(
+            "()",
+            new JsonUrlStringBuilder(JsonUrlOption.AQF)
+                .beginObject()
+                .endObject()
+                .build(),
+            testName);
+
+        assertEquals(
+            "(:)",
+            new JsonUrlStringBuilder(JsonUrlOption.NO_EMPTY_COMPOSITE)
+                .beginObject()
+                .endObject()
+                .build(),
+            testName);
+
+        assertEquals(
+            "(:)",
+            new JsonUrlStringBuilder(
+                    JsonUrlOption.AQF,
+                    JsonUrlOption.NO_EMPTY_COMPOSITE)
+                .beginObject()
+                .endObject()
+                .build(),
+            testName);
+    }
 
     @Test
     void testEmptyString() throws IOException {
@@ -164,6 +199,11 @@ class JsonUrlStringBuilderTest {
         assertEquals(
             EMPTY_QSTRING,
             new JsonUrlStringBuilder().add(EMPTY_STRING).build(),
+            testName);
+
+        assertEquals(
+            EMPTY_QSTRING,
+            new JsonUrlStringBuilder().addKey(EMPTY_STRING).build(),
             testName);
 
         assertEquals(
@@ -435,10 +475,17 @@ class JsonUrlStringBuilderTest {
 
     @Test
     void testText5() throws IOException {
-        String expected = "''";
+        String expected = "(a:(:))";
         assertEquals(
             expected,
-            new JsonUrlStringBuilder().addKey("").build(),
+            new JsonUrlStringBuilder(JsonUrlOption.NO_EMPTY_COMPOSITE)
+            .beginObject()
+            .addKey("a")
+            .nameSeparator()
+            .beginObject()
+            .endObject()
+            .endObject()
+            .build(),
             expected);
     }
     

--- a/module/jsonurl-factory/src/test/java/org/jsonurl/factory/AbstractParseTest.java
+++ b/module/jsonurl-factory/src/test/java/org/jsonurl/factory/AbstractParseTest.java
@@ -1285,6 +1285,23 @@ public abstract class AbstractParseTest<
             assertJsonUrlText8(text, parseImpliedFactoryObject(text, 0, text.length(), false));
         }
 
+        @ParameterizedTest
+        @ValueSource(strings = {"(:)"})
+        void testJsonUrlText9(String text) throws IOException {
+            assertTrue(isEmptyObject(parseFactoryObject(text,
+                EnumSet.of(JsonUrlOption.NO_EMPTY_COMPOSITE))), text);
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = {"%28%3a%29"})
+        void testJsonUrlText10(String text) throws IOException {
+            assertTrue(
+                isEmptyObject(parseFactoryObject(text,
+                    EnumSet.of(JsonUrlOption.AQF,
+                        JsonUrlOption.NO_EMPTY_COMPOSITE))),
+                text);
+        }
+
     }
 
     /**
@@ -1306,6 +1323,34 @@ public abstract class AbstractParseTest<
             assertEquals(text, txt, text);
             assertTrue(factory.isEmptyComposite(
                 newParser().parse(text)), text);
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = { "(:)" })
+        void testNoEmptyCompositeObject(String text) throws IOException {
+            J expected = factory.newObject(factory.newObjectBuilder());
+
+            assertParse(text,
+                newOptions(JsonUrlOption.NO_EMPTY_COMPOSITE),
+                expected);
+
+            assertParse(text,
+                newOptions(JsonUrlOption.AQF, JsonUrlOption.NO_EMPTY_COMPOSITE),
+                expected);
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = { "()" })
+        void testNoEmptyCompositeArray(String text) throws IOException {
+            A expected = factory.newArray(factory.newArrayBuilder());
+
+            assertParse(text,
+                newOptions(JsonUrlOption.NO_EMPTY_COMPOSITE),
+                expected);
+
+            assertParse(text,
+                newOptions(JsonUrlOption.AQF, JsonUrlOption.NO_EMPTY_COMPOSITE),
+                expected);
         }
         
         @ParameterizedTest
@@ -2177,6 +2222,9 @@ public abstract class AbstractParseTest<
 
     /** Get the size of the given array. */
     protected abstract int getSize(A value);
+
+    /** Test if the given object is empty. */
+    protected abstract boolean isEmptyObject(J value);
 
     /** Create a new bing math factory. */
     protected abstract ValueFactory<V,C,ABT,A,JBT,J,B,M,N,S> newBigMathFactory(

--- a/module/jsonurl-factory/src/test/java/org/jsonurl/factory/AbstractWriteTest.java
+++ b/module/jsonurl-factory/src/test/java/org/jsonurl/factory/AbstractWriteTest.java
@@ -366,6 +366,56 @@ public abstract class AbstractWriteTest<
             false);
     }
 
+    @Test
+    void testEmptyObject() throws IOException {
+        String text = "(:)";
+
+        V value = newParser(JsonUrlOption.NO_EMPTY_COMPOSITE)
+            .parseObject(text);
+
+        String actual = newJsonStringBuilder(
+                EnumSet.of(JsonUrlOption.NO_EMPTY_COMPOSITE))
+            .add(value)
+            .build();
+
+        assertEquals(text, actual, text);
+    }
+
+    @Test
+    void testEmptyObjectNested() throws IOException {
+        String text = "a:(:)";
+
+        V value = newParser(JsonUrlOption.NO_EMPTY_COMPOSITE)
+            .parseObject(text, factory.newObjectBuilder());
+
+        String actual = newJsonStringBuilder(
+                EnumSet.of(JsonUrlOption.NO_EMPTY_COMPOSITE),
+                CompositeType.OBJECT)
+            .add(value)
+            .build();
+
+        assertEquals(text, actual, text);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+        "(:)",
+        "((:))",
+        "(((:)))",
+    })
+    void testEmptyObjectInImpliedArray(String text) throws IOException {
+        V value = newParser(JsonUrlOption.NO_EMPTY_COMPOSITE)
+            .parseArray(text, factory.newArrayBuilder());
+
+        String actual = newJsonStringBuilder(
+                EnumSet.of(JsonUrlOption.NO_EMPTY_COMPOSITE),
+                CompositeType.ARRAY)
+            .add(value)
+            .build();
+
+        assertEquals(text, actual, text);
+    }
+
     @ParameterizedTest
     @ValueSource(strings = {
         "1.234",

--- a/module/jsonurl-factory/src/test/java/org/jsonurl/j2se/AbstractJavaValueFactoryParseTest.java
+++ b/module/jsonurl-factory/src/test/java/org/jsonurl/j2se/AbstractJavaValueFactoryParseTest.java
@@ -136,6 +136,11 @@ abstract class AbstractJavaValueFactoryParseTest extends AbstractParseTest<
     }
 
     @Override
+    protected boolean isEmptyObject(Map<String,Object> value) {
+        return !factory.isNull(value) && value.isEmpty();
+    }
+
+    @Override
     protected JavaValueFactory newBigMathFactory(
                 MathContext mctxt,
                 String boundNeg,

--- a/module/jsonurl-jsonorg/src/test/java/org/jsonurl/jsonorg/AbstractJsonOrgParseTest.java
+++ b/module/jsonurl-jsonorg/src/test/java/org/jsonurl/jsonorg/AbstractJsonOrgParseTest.java
@@ -133,6 +133,11 @@ abstract class AbstractJsonOrgParseTest extends AbstractParseTest<
     }
 
     @Override
+    protected boolean isEmptyObject(JSONObject value) {
+        return !factory.isNull(value) && value.isEmpty();
+    }
+
+    @Override
     protected ValueFactory<
             Object,
             Object,

--- a/module/jsonurl-jsr374/src/test/java/org/jsonurl/jsonp/AbstractJsonpParseTest.java
+++ b/module/jsonurl-jsr374/src/test/java/org/jsonurl/jsonp/AbstractJsonpParseTest.java
@@ -144,6 +144,11 @@ abstract class AbstractJsonpParseTest extends AbstractParseTest<
     }
 
     @Override
+    protected boolean isEmptyObject(JsonObject value) {
+        return !factory.isNull(value) && value.isEmpty();
+    }
+
+    @Override
     protected ValueFactory<
             JsonValue,
             JsonStructure,


### PR DESCRIPTION
The commit includes support for both parsing and generating empty
objects/arrays as outlined in section 2.9.5 of the spec.