### PR TITLE
fix: Fix bug writing number-like strings that include plus, with AQF

### DIFF
--- a/module/jsonurl-core/src/main/java/org/jsonurl/text/JsonUrlTextAppender.java
+++ b/module/jsonurl-core/src/main/java/org/jsonurl/text/JsonUrlTextAppender.java
@@ -89,7 +89,7 @@ public abstract class JsonUrlTextAppender<A extends Appendable, R> // NOPMD
      * @param dest JSON&#x2192;URL text destination
      * @param options Set of JsonUrlOptions
      */
-    public JsonUrlTextAppender(
+    protected JsonUrlTextAppender(
             A dest,
             CompositeType impliedType,
             Set<JsonUrlOption> options) {
@@ -504,7 +504,12 @@ public abstract class JsonUrlTextAppender<A extends Appendable, R> // NOPMD
                 dest.append(text, start, end);
 
             } else if (optionAQF(options)) {
-                dest.append('!').append(text, start, end);
+                if (contains(text, start, end, '+')) {
+                    encodeAqf(dest, text, start, end);
+
+                } else {
+                    dest.append('!').append(text, start, end);                    
+                }
 
             } else if (contains(text, start, end, '+')) {
                 encode(dest, text, start, end, false, false);

--- a/module/jsonurl-factory/src/test/java/org/jsonurl/factory/AbstractParseTest.java
+++ b/module/jsonurl-factory/src/test/java/org/jsonurl/factory/AbstractParseTest.java
@@ -651,9 +651,9 @@ public abstract class AbstractParseTest<
                     newParser(newOptions(option)).parse("1e%2B1"),
                     desc);
 
-                // stringify("1e+1") -> string("1e%2B1")
+                // stringify("1e+1") -> string("1e!+1")
                 assertEquals(
-                    "!1e+1",
+                    "1e!+1",
                     new JsonUrlStringBuilder(
                         newOptions(option)).add("1e+1").build(),
                     desc);


### PR DESCRIPTION
A string like "1e+6" must be represented as 1e!+6, where the plus is
escaped. Otherwise, the plus will be decoded as a space when it's later
parsed.