### PR TITLE
style: Update maven checkstyle plugin version

### DIFF
--- a/config/checkstyle.xml
+++ b/config/checkstyle.xml
@@ -191,7 +191,7 @@ Checkstyle configuration that checks the Google coding conventions from Google J
     </module>
     <module name="JavadocMethod">
       <property name="allowedAnnotations" value="Override, Test"/>
-      <property name="scope" value="public"/>
+      <property name="accessModifiers" value="public"/>
       <property name="allowMissingParamTags" value="true"/>
       <property name="allowMissingReturnTag" value="true"/>
       <property name="tokens" value="METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF"/>

--- a/module/jsonurl-core/src/main/java/org/jsonurl/stream/AbstractCharIterator.java
+++ b/module/jsonurl-core/src/main/java/org/jsonurl/stream/AbstractCharIterator.java
@@ -89,7 +89,7 @@ public abstract class AbstractCharIterator implements CharIterator {
      * Create a new AbstractCharIterator.
      * @param name Resource {@link Resource#getName() name}
      * @param limit maximum number of parsed characters before a
-     *  {@link org.jsonurl.LimitException LimitException} is thrown. 
+     *     {@link org.jsonurl.LimitException LimitException} is thrown. 
      */
     public AbstractCharIterator(String name, long limit) {
         this.name = name;

--- a/module/jsonurl-core/src/main/java/org/jsonurl/stream/JsonUrlCharSequence.java
+++ b/module/jsonurl-core/src/main/java/org/jsonurl/stream/JsonUrlCharSequence.java
@@ -80,7 +80,7 @@ public class JsonUrlCharSequence extends AbstractCharIterator
      * @param name the resource {@link Resource#getName() name}
      * @param text a valid CharSequence
      * @param limit maximum number of parsed characters before a
-     *  {@link org.jsonurl.LimitException LimitException} is thrown.
+     *     {@link org.jsonurl.LimitException LimitException} is thrown.
      */
     public JsonUrlCharSequence(String name, CharSequence text, long limit) {
         this(name, text, 0, text.length(), limit);
@@ -93,7 +93,7 @@ public class JsonUrlCharSequence extends AbstractCharIterator
      * @param offset starting offset
      * @param length stop when this length is reached
      * @param limit maximum number of parsed characters before a
-     *  {@link org.jsonurl.LimitException LimitException} is thrown.
+     *     {@link org.jsonurl.LimitException LimitException} is thrown.
      */
     public JsonUrlCharSequence(
             String name,

--- a/module/jsonurl-core/src/test/java/org/jsonurl/text/JsonUrlStringBuilderTest.java
+++ b/module/jsonurl-core/src/test/java/org/jsonurl/text/JsonUrlStringBuilderTest.java
@@ -530,10 +530,10 @@ class JsonUrlStringBuilderTest {
     @ParameterizedTest
     @Tag("exception")
     @ValueSource(strings = {
-            Character.MIN_LOW_SURROGATE + "" + Character.MIN_HIGH_SURROGATE, // NOPMD
-            Character.MIN_HIGH_SURROGATE + "", // NOPMD
-            Character.MIN_HIGH_SURROGATE + "" + Character.MIN_HIGH_SURROGATE, // NOPMD
-            Character.MAX_HIGH_SURROGATE + "" + (Character.MAX_LOW_SURROGATE + 1), // NOPMD
+        Character.MIN_LOW_SURROGATE + "" + Character.MIN_HIGH_SURROGATE, // NOPMD
+        Character.MIN_HIGH_SURROGATE + "", // NOPMD
+        Character.MIN_HIGH_SURROGATE + "" + Character.MIN_HIGH_SURROGATE, // NOPMD
+        Character.MAX_HIGH_SURROGATE + "" + (Character.MAX_LOW_SURROGATE + 1), // NOPMD
     })
     void testExceptionUtf8(String text) throws IOException {
         assertThrows(

--- a/module/jsonurl-factory/src/test/java/org/jsonurl/factory/AbstractParseTest.java
+++ b/module/jsonurl-factory/src/test/java/org/jsonurl/factory/AbstractParseTest.java
@@ -208,12 +208,12 @@ public abstract class AbstractParseTest<
 
         @ParameterizedTest
         @ValueSource(strings = {
-                "(1)",
-                "(a(",
-                "(a:",
-                "(a:b(",
-                "(a:b,a",
-                "(a:b,c&)",
+            "(1)",
+            "(a(",
+            "(a:",
+            "(a:b(",
+            "(a:b,a",
+            "(a:b,c&)",
         })
         void testExceptionObject(String text) {
             assertThrows(
@@ -228,8 +228,8 @@ public abstract class AbstractParseTest<
 
         @ParameterizedTest
         @ValueSource(strings = {
-                "(a:b)",
-                "(a(",
+            "(a:b)",
+            "(a(",
         })
         void testExceptionArray(String text) {
             assertThrows(
@@ -802,10 +802,10 @@ public abstract class AbstractParseTest<
         
         @ParameterizedTest
         @ValueSource(strings = {
-                HELLO,
-                "t", "tr", "tru", "True", "tRue", "trUe", "truE",
-                "f", "fa", "fal", "fals", "False", "fAlse", "faLse", "falSe", "falsE",
-                "n", "nu", "nul", "Null", "nUll", "nuLl", "nulL",
+            HELLO,
+            "t", "tr", "tru", "True", "tRue", "trUe", "truE",
+            "f", "fa", "fal", "fals", "False", "fAlse", "faLse", "falSe", "falsE",
+            "n", "nu", "nul", "Null", "nUll", "nuLl", "nulL",
         })
         void testString(String text) throws IOException {
             assertParse(text, getFactoryString(text));
@@ -865,13 +865,13 @@ public abstract class AbstractParseTest<
             // https://www.piday.org/million/
             //
             "3.14159265358979323846264338327950288419716939937510582097494459230781"
-            + "64062862089986280348253421170679821480865132823066470938446095505822"
-            + "31725359408128481117450284102701938521105559644622948954930381964428"
-            + "81097566593344612847564823378678316527120190914564856692346034861045"
-            + "43266482133936072602491412737245870066063155881748815209209628292540"
-            + "91715364367892590360011330530548820466521384146951941511609433057270"
-            + "36575959195309218611738193261179310511854807446237996274956735188575"
-            + "2724891227938183011949"
+                + "64062862089986280348253421170679821480865132823066470938446095505822"
+                + "31725359408128481117450284102701938521105559644622948954930381964428"
+                + "81097566593344612847564823378678316527120190914564856692346034861045"
+                + "43266482133936072602491412737245870066063155881748815209209628292540"
+                + "91715364367892590360011330530548820466521384146951941511609433057270"
+                + "36575959195309218611738193261179310511854807446237996274956735188575"
+                + "2724891227938183011949"
         })
         void testMathContext(String text) throws IOException {
             if (factory instanceof BigMathProvider) {

--- a/module/pom.xml
+++ b/module/pom.xml
@@ -48,7 +48,7 @@
     <maven.surefire.plugin>2.22.2</maven.surefire.plugin>
     <maven.surefire.report.plugin>2.22.2</maven.surefire.report.plugin>
     <maven.javadoc.plugin>3.2.0</maven.javadoc.plugin>
-    <maven.checkstyle.plugin>3.1.1</maven.checkstyle.plugin>
+    <maven.checkstyle.plugin>3.1.2</maven.checkstyle.plugin>
     <maven.pmd.plugin>3.13.0</maven.pmd.plugin>
     <maven.jacoco.plugin>0.8.5</maven.jacoco.plugin>
     <maven.gpg.plugin>1.6</maven.gpg.plugin>
@@ -60,6 +60,14 @@
     <nexus.staging.plugin>1.6.8</nexus.staging.plugin>
     <codehaus.versions.plugin>2.7</codehaus.versions.plugin>
     <sonar.maven.plugin>3.7.0.1746</sonar.maven.plugin>
+    
+    <!--
+        This should track the version used by the Eclipse CHeckstyle Plugin
+            https://checkstyle.org/eclipse-cs/
+
+        Doing so allows both to share the same config file.
+    -->
+    <checkstyle.version>8.43</checkstyle.version>
 
     <nexus.url>https://oss.sonatype.org</nexus.url>
 
@@ -200,6 +208,13 @@
             <linkXRef>false</linkXRef>
             <includeTestSourceDirectory>true</includeTestSourceDirectory>
           </configuration>
+          <dependencies>
+            <dependency>
+                <groupId>com.puppycrawl.tools</groupId>
+                <artifactId>checkstyle</artifactId>
+                <version>${checkstyle.version}</version>
+            </dependency>
+          </dependencies>
         </plugin>
         <plugin>
           <artifactId>maven-pmd-plugin</artifactId>


### PR DESCRIPTION
I upgraded the Eclipse checkstyle plugin (eclipse-cs), however,
some parameter names changed. Updating the config to use the same
name is straightforward, but now the maven plugin (which still uses
the older version of checkstyle) causes the build to fail.

This patch changes the parent POM to track the same version of
checkstyle that the Eclipse plugin uses. That allows me
to use the same config for both.

This patch also fixes some style violations -- otherwise, the build
would fail. ;)