### PR TITLE
chore: Update PMD

### DIFF
--- a/SuppressWarnings.md
+++ b/SuppressWarnings.md
@@ -34,6 +34,7 @@ make it harder to follow the logic due to the additional indirection.
     // See SuppressWarnings.md#complexity
     "PMD.CyclomaticComplexity",
     "PMD.NPathComplexity",
+    "PMD.CognitiveComplexity",
     "java:S3776"
 })
 ```
@@ -85,4 +86,11 @@ couldn't find a PMD parameter that allows me to change the regex.
 ```java
 @SuppressWarnings({"PMD.GenericsNaming", "java:S119"}) // See SuppressWarnings.md
 ```
+## Duplicate Literals
 
+Though it is generally good to avoid duplicate literals, inline literals in
+unit tests often makes them much easier to read.
+
+```java
+@SuppressWarnings("PMD.AvoidDuplicateLiterals") // See SuppressWarnings.md
+```

--- a/config/pmd-ruleset.xml
+++ b/config/pmd-ruleset.xml
@@ -26,7 +26,11 @@
    <rule ref="category/java/bestpractices.xml/JUnit4TestShouldUseAfterAnnotation"/>
    <rule ref="category/java/bestpractices.xml/JUnit4TestShouldUseBeforeAnnotation"/>
    <rule ref="category/java/bestpractices.xml/JUnit4TestShouldUseTestAnnotation"/>
+   <rule ref="category/java/bestpractices.xml/JUnit5TestShouldBePackagePrivate"/>
    <rule ref="category/java/bestpractices.xml/JUnitAssertionsShouldIncludeMessage"/>
+<!--
+   <rule ref="category/java/bestpractices.xml/JUnitTestContainsTooManyAsserts"/>
+-->
    <rule ref="category/java/bestpractices.xml/JUnitTestsShouldIncludeAssert"/>
    <rule ref="category/java/bestpractices.xml/JUnitUseExpected"/>
    <rule ref="category/java/bestpractices.xml/LiteralsFirstInComparisons"/>
@@ -35,39 +39,43 @@
    <rule ref="category/java/bestpractices.xml/MissingOverride"/>
    <rule ref="category/java/bestpractices.xml/OneDeclarationPerLine"/>
    <rule ref="category/java/bestpractices.xml/PreserveStackTrace"/>
+   <rule ref="category/java/bestpractices.xml/PrimitiveWrapperInstantiation"/>
    <rule ref="category/java/bestpractices.xml/ReplaceEnumerationWithIterator"/>
    <rule ref="category/java/bestpractices.xml/ReplaceHashtableWithMap"/>
    <rule ref="category/java/bestpractices.xml/ReplaceVectorWithList"/>
+   <rule ref="category/java/bestpractices.xml/SimplifiableTestAssertion"/>
    <rule ref="category/java/bestpractices.xml/SwitchStmtsShouldHaveDefault"/>
    <rule ref="category/java/bestpractices.xml/SystemPrintln"/>
    <rule ref="category/java/bestpractices.xml/UnusedAssignment"/>
    <rule ref="category/java/bestpractices.xml/UnusedFormalParameter"/>
-   <rule ref="category/java/bestpractices.xml/UnusedImports"/>
    <rule ref="category/java/bestpractices.xml/UnusedLocalVariable"/>
    <rule ref="category/java/bestpractices.xml/UnusedPrivateField"/>
    <rule ref="category/java/bestpractices.xml/UnusedPrivateMethod"/>
-   <rule ref="category/java/bestpractices.xml/UseAssertEqualsInsteadOfAssertTrue"/>
-   <rule ref="category/java/bestpractices.xml/UseAssertNullInsteadOfAssertTrue"/>
-   <rule ref="category/java/bestpractices.xml/UseAssertSameInsteadOfAssertTrue"/>
-   <rule ref="category/java/bestpractices.xml/UseAssertTrueInsteadOfAssertEquals"/>
    <rule ref="category/java/bestpractices.xml/UseCollectionIsEmpty"/>
+   <rule ref="category/java/bestpractices.xml/UseStandardCharsets"/>
    <rule ref="category/java/bestpractices.xml/UseTryWithResources"/>
    <rule ref="category/java/bestpractices.xml/UseVarargs"/>
    <rule ref="category/java/bestpractices.xml/WhileLoopWithLiteralBoolean"/>
+<!--
+   <rule ref="category/java/codestyle.xml/AtLeastOneConstructor"/>
+-->
    <rule ref="category/java/codestyle.xml/AvoidDollarSigns"/>
    <rule ref="category/java/codestyle.xml/AvoidProtectedFieldInFinalClass"/>
    <rule ref="category/java/codestyle.xml/AvoidProtectedMethodInFinalClassNotExtending"/>
    <rule ref="category/java/codestyle.xml/AvoidUsingNativeCode"/>
    <rule ref="category/java/codestyle.xml/BooleanGetMethodName"/>
+   <rule ref="category/java/codestyle.xml/CallSuperInConstructor"/>
    <rule ref="category/java/codestyle.xml/ClassNamingConventions"/>
+<!--
+   <rule ref="category/java/codestyle.xml/CommentDefaultAccessModifier"/>
+-->
    <rule ref="category/java/codestyle.xml/ConfusingTernary"/>
    <rule ref="category/java/codestyle.xml/ControlStatementBraces"/>
-   <rule ref="category/java/codestyle.xml/DontImportJavaLang"/>
-   <rule ref="category/java/codestyle.xml/DuplicateImports"/>
    <rule ref="category/java/codestyle.xml/EmptyMethodInAbstractClassShouldBeAbstract"/>
    <rule ref="category/java/codestyle.xml/ExtendsObject"/>
    <rule ref="category/java/codestyle.xml/FieldDeclarationsShouldBeAtStartOfClass"/>
    <rule ref="category/java/codestyle.xml/FieldNamingConventions"/>
+   <rule ref="category/java/codestyle.xml/FinalParameterInAbstractMethod"/>
    <rule ref="category/java/codestyle.xml/ForLoopShouldBeWhileLoop"/>
    <rule ref="category/java/codestyle.xml/FormalParameterNamingConventions"/>
    <rule ref="category/java/codestyle.xml/GenericsNaming"/>
@@ -75,10 +83,23 @@
    <rule ref="category/java/codestyle.xml/LinguisticNaming"/>
    <rule ref="category/java/codestyle.xml/LocalHomeNamingConvention"/>
    <rule ref="category/java/codestyle.xml/LocalInterfaceSessionNamingConvention"/>
+<!--
+   <rule ref="category/java/codestyle.xml/LocalVariableCouldBeFinal"/>
+-->
    <rule ref="category/java/codestyle.xml/LocalVariableNamingConventions"/>
+<!--
+   <rule ref="category/java/codestyle.xml/LongVariable"/>
+-->
    <rule ref="category/java/codestyle.xml/MDBAndSessionBeanNamingConvention"/>
+<!--
+   <rule ref="category/java/codestyle.xml/MethodArgumentCouldBeFinal"/>
+-->
    <rule ref="category/java/codestyle.xml/MethodNamingConventions"/>
    <rule ref="category/java/codestyle.xml/NoPackage"/>
+   <rule ref="category/java/codestyle.xml/UseUnderscoresInNumericLiterals"/>
+<!--
+   <rule ref="category/java/codestyle.xml/OnlyOneReturn"/>
+-->
    <rule ref="category/java/codestyle.xml/PackageCase"/>
    <rule ref="category/java/codestyle.xml/PrematureDeclaration"/>
    <rule ref="category/java/codestyle.xml/RemoteInterfaceNamingConvention"/>
@@ -86,10 +107,14 @@
    <rule ref="category/java/codestyle.xml/ShortClassName"/>
    <rule ref="category/java/codestyle.xml/ShortMethodName"/>
    <rule ref="category/java/codestyle.xml/ShortVariable"/>
+<!--
+   <rule ref="category/java/codestyle.xml/TooManyStaticImports"/>
+-->
    <rule ref="category/java/codestyle.xml/UnnecessaryAnnotationValueElement"/>
    <rule ref="category/java/codestyle.xml/UnnecessaryCast"/>
    <rule ref="category/java/codestyle.xml/UnnecessaryConstructor"/>
    <rule ref="category/java/codestyle.xml/UnnecessaryFullyQualifiedName"/>
+   <rule ref="category/java/codestyle.xml/UnnecessaryImport"/>
    <rule ref="category/java/codestyle.xml/UnnecessaryLocalBeforeReturn"/>
    <rule ref="category/java/codestyle.xml/UnnecessaryModifier"/>
    <rule ref="category/java/codestyle.xml/UnnecessaryReturn"/>
@@ -108,34 +133,52 @@
    <rule ref="category/java/design.xml/ClassWithOnlyPrivateConstructorsShouldBeFinal"/>
    <rule ref="category/java/design.xml/CollapsibleIfStatements"/>
    <rule ref="category/java/design.xml/CouplingBetweenObjects"/>
+   <rule ref="category/java/design.xml/CognitiveComplexity"/>
    <rule ref="category/java/design.xml/CyclomaticComplexity"/>
    <rule ref="category/java/design.xml/DataClass"/>
    <rule ref="category/java/design.xml/DoNotExtendJavaLangError"/>
    <rule ref="category/java/design.xml/ExceptionAsFlowControl"/>
+   <rule ref="category/java/design.xml/ExcessiveClassLength"/>
 <!--
    <rule ref="category/java/design.xml/ExcessiveImports"/>
 -->
+   <rule ref="category/java/design.xml/ExcessiveMethodLength"/>
    <rule ref="category/java/design.xml/ExcessiveParameterList"/>
    <rule ref="category/java/design.xml/ExcessivePublicCount"/>
    <rule ref="category/java/design.xml/FinalFieldCouldBeStatic"/>
+<!--
+   <rule ref="category/java/design.xml/GodClass"/>
+-->
    <rule ref="category/java/design.xml/ImmutableField"/>
+<!--
+   <rule ref="category/java/design.xml/LawOfDemeter"/>
+-->
    <rule ref="category/java/design.xml/LogicInversion"/>
+<!--
+   <rule ref="category/java/design.xml/LoosePackageCoupling"/>
+-->
    <rule ref="category/java/design.xml/NcssCount"/>
    <rule ref="category/java/design.xml/NPathComplexity"/>
    <rule ref="category/java/design.xml/SignatureDeclareThrowsException"/>
    <rule ref="category/java/design.xml/SimplifiedTernary"/>
-   <rule ref="category/java/design.xml/SimplifyBooleanAssertion"/>
    <rule ref="category/java/design.xml/SimplifyBooleanExpressions"/>
    <rule ref="category/java/design.xml/SimplifyBooleanReturns"/>
    <rule ref="category/java/design.xml/SimplifyConditional"/>
    <rule ref="category/java/design.xml/SingularField"/>
    <rule ref="category/java/design.xml/SwitchDensity"/>
    <rule ref="category/java/design.xml/TooManyFields"/>
+<!--
+   <rule ref="category/java/design.xml/TooManyMethods"/>
+-->
    <rule ref="category/java/design.xml/UselessOverridingMethod"/>
    <rule ref="category/java/design.xml/UseObjectForClearerAPI"/>
    <rule ref="category/java/design.xml/UseUtilityClass"/>
+   <rule ref="category/java/design.xml/MutableStaticState"/>
    <rule ref="category/java/documentation.xml/CommentContent"/>
    <rule ref="category/java/documentation.xml/CommentRequired"/>
+<!--
+   <rule ref="category/java/documentation.xml/CommentSize"/>
+-->
    <rule ref="category/java/documentation.xml/UncommentedEmptyConstructor"/>
    <rule ref="category/java/documentation.xml/UncommentedEmptyMethodBody"/>
    <rule ref="category/java/errorprone.xml/AssignmentInOperand"/>
@@ -149,6 +192,7 @@
    <rule ref="category/java/errorprone.xml/AvoidDecimalLiteralsInBigDecimalConstructor"/>
    <rule ref="category/java/errorprone.xml/AvoidDuplicateLiterals"/>
    <rule ref="category/java/errorprone.xml/AvoidEnumAsIdentifier"/>
+
 <!--
    <rule ref="category/java/errorprone.xml/AvoidFieldNameMatchingMethodName"/>
 -->
@@ -158,7 +202,9 @@
    <rule ref="category/java/errorprone.xml/AvoidLosingExceptionInformation"/>
    <rule ref="category/java/errorprone.xml/AvoidMultipleUnaryOperators"/>
    <rule ref="category/java/errorprone.xml/AvoidUsingOctalValues"/>
-   <rule ref="category/java/errorprone.xml/BadComparison"/>
+<!--
+   <rule ref="category/java/errorprone.xml/BeanMembersShouldSerialize"/>
+-->
    <rule ref="category/java/errorprone.xml/BrokenNullCheck"/>
    <rule ref="category/java/errorprone.xml/CallSuperFirst"/>
    <rule ref="category/java/errorprone.xml/CallSuperLast"/>
@@ -167,14 +213,15 @@
    <rule ref="category/java/errorprone.xml/CloneMethodMustBePublic"/>
    <rule ref="category/java/errorprone.xml/CloneMethodMustImplementCloneable"/>
    <rule ref="category/java/errorprone.xml/CloneMethodReturnTypeMustMatchClassName"/>
-   <rule ref="category/java/errorprone.xml/CloneThrowsCloneNotSupportedException"/>
    <rule ref="category/java/errorprone.xml/CloseResource"/>
    <rule ref="category/java/errorprone.xml/CompareObjectsWithEquals"/>
+   <rule ref="category/java/errorprone.xml/ComparisonWithNaN"/>
    <rule ref="category/java/errorprone.xml/ConstructorCallsOverridableMethod"/>
    <rule ref="category/java/errorprone.xml/DetachedTestCase"/>
    <rule ref="category/java/errorprone.xml/DoNotCallGarbageCollectionExplicitly"/>
    <rule ref="category/java/errorprone.xml/DoNotExtendJavaLangThrowable"/>
    <rule ref="category/java/errorprone.xml/DoNotHardCodeSDCard"/>
+   <rule ref="category/java/errorprone.xml/DoNotTerminateVM"/>
    <rule ref="category/java/errorprone.xml/DoNotThrowExceptionInFinally"/>
    <rule ref="category/java/errorprone.xml/DontImportSun"/>
    <rule ref="category/java/errorprone.xml/DontUseFloatTypeForLoopIndices"/>
@@ -195,7 +242,7 @@
    <rule ref="category/java/errorprone.xml/FinalizeOverloaded"/>
    <rule ref="category/java/errorprone.xml/FinalizeShouldBeProtected"/>
    <rule ref="category/java/errorprone.xml/IdempotentOperations"/>
-   <rule ref="category/java/errorprone.xml/ImportFromSamePackage"/>
+   <rule ref="category/java/errorprone.xml/ImplicitSwitchFallThrough"/>
    <rule ref="category/java/errorprone.xml/InstantiationToGetClass"/>
    <rule ref="category/java/errorprone.xml/InvalidLogMessageFormat"/>
    <rule ref="category/java/errorprone.xml/JumbledIncrementer"/>
@@ -203,7 +250,6 @@
    <rule ref="category/java/errorprone.xml/JUnitStaticSuite"/>
    <rule ref="category/java/errorprone.xml/MethodWithSameNameAsEnclosingClass"/>
    <rule ref="category/java/errorprone.xml/MisplacedNullCheck"/>
-   <rule ref="category/java/errorprone.xml/MissingBreakInSwitch"/>
    <rule ref="category/java/errorprone.xml/MissingSerialVersionUID"/>
    <rule ref="category/java/errorprone.xml/MissingStaticMethodInNonInstantiatableClass"/>
    <rule ref="category/java/errorprone.xml/MoreThanOneLogger"/>
@@ -213,7 +259,9 @@
    <rule ref="category/java/errorprone.xml/OverrideBothEqualsAndHashcode"/>
    <rule ref="category/java/errorprone.xml/ProperCloneImplementation"/>
    <rule ref="category/java/errorprone.xml/ProperLogger"/>
-   <rule ref="category/java/errorprone.xml/ReturnEmptyArrayRatherThanNull"/>
+<!--
+   <rule ref="category/java/errorprone.xml/ReturnEmptyCollectionRatherThanNull"/>
+-->
    <rule ref="category/java/errorprone.xml/ReturnFromFinallyBlock"/>
    <rule ref="category/java/errorprone.xml/SimpleDateFormatNeedsLocale"/>
    <rule ref="category/java/errorprone.xml/SingleMethodSingleton"/>
@@ -242,6 +290,7 @@
    <rule ref="category/java/multithreading.xml/DoubleCheckedLocking"/>
    <rule ref="category/java/multithreading.xml/NonThreadSafeSingleton"/>
    <rule ref="category/java/multithreading.xml/UnsynchronizedStaticFormatter"/>
+   <rule ref="category/java/multithreading.xml/UseConcurrentHashMap"/>
    <rule ref="category/java/multithreading.xml/UseNotifyAllInsteadOfNotify"/>
    <rule ref="category/java/performance.xml/AddEmptyString"/>
    <rule ref="category/java/performance.xml/AppendCharacterWithChar"/>
@@ -249,24 +298,17 @@
    <rule ref="category/java/performance.xml/AvoidCalendarDateCreation"/>
    <rule ref="category/java/performance.xml/AvoidFileStream"/>
    <rule ref="category/java/performance.xml/AvoidInstantiatingObjectsInLoops"/>
-   <rule ref="category/java/performance.xml/AvoidUsingShortType"/>
    <rule ref="category/java/performance.xml/BigIntegerInstantiation"/>
-   <rule ref="category/java/performance.xml/BooleanInstantiation"/>
-   <rule ref="category/java/performance.xml/ByteInstantiation"/>
    <rule ref="category/java/performance.xml/ConsecutiveAppendsShouldReuse"/>
    <rule ref="category/java/performance.xml/ConsecutiveLiteralAppends"/>
    <rule ref="category/java/performance.xml/InefficientEmptyStringCheck"/>
    <rule ref="category/java/performance.xml/InefficientStringBuffering"/>
    <rule ref="category/java/performance.xml/InsufficientStringBufferDeclaration"/>
-   <rule ref="category/java/performance.xml/IntegerInstantiation"/>
-   <rule ref="category/java/performance.xml/LongInstantiation"/>
    <rule ref="category/java/performance.xml/OptimizableToArrayCall"/>
    <rule ref="category/java/performance.xml/RedundantFieldInitializer"/>
-   <rule ref="category/java/performance.xml/ShortInstantiation"/>
    <rule ref="category/java/performance.xml/StringInstantiation"/>
    <rule ref="category/java/performance.xml/StringToString"/>
    <rule ref="category/java/performance.xml/TooFewBranchesForASwitchStatement"/>
-   <rule ref="category/java/performance.xml/UnnecessaryWrapperObjectCreation"/>
    <rule ref="category/java/performance.xml/UseArrayListInsteadOfVector"/>
    <rule ref="category/java/performance.xml/UseArraysAsList"/>
    <rule ref="category/java/performance.xml/UseIndexOfChar"/>
@@ -275,6 +317,30 @@
    <rule ref="category/java/performance.xml/UseStringBufferForStringAppends"/>
    <rule ref="category/java/performance.xml/UseStringBufferLength"/>
    <rule ref="category/java/security.xml/HardCodedCryptoKey"/>
+   <rule ref="category/java/security.xml/InsecureCryptoIv"/>
+   <rule ref="category/jsp/bestpractices.xml/DontNestJsfInJstlIteration"/>
+   <rule ref="category/jsp/bestpractices.xml/NoClassAttribute"/>
+   <rule ref="category/jsp/bestpractices.xml/NoHtmlComments"/>
+   <rule ref="category/jsp/bestpractices.xml/NoJspForward"/>
+   <rule ref="category/jsp/codestyle.xml/DuplicateJspImports"/>
+   <rule ref="category/jsp/design.xml/NoInlineScript"/>
+   <rule ref="category/jsp/design.xml/NoInlineStyleInformation"/>
+   <rule ref="category/jsp/design.xml/NoLongScripts"/>
+   <rule ref="category/jsp/design.xml/NoScriptlets"/>
+   <rule ref="category/jsp/errorprone.xml/JspEncoding"/>
    <rule ref="category/jsp/security.xml/IframeMissingSrcAttribute"/>
    <rule ref="category/jsp/security.xml/NoUnsanitizedJSPExpression"/>
+<!-- not found?
+   <rule ref="category/pom/errorprone.xml/InvalidDependencyTypes"/>
+   <rule ref="category/pom/errorprone.xml/ProjectVersionAsDependencyVersion"/>
+   <rule ref="category/vm/bestpractices.xml/AvoidReassigningParameters"/>
+   <rule ref="category/vm/bestpractices.xml/UnusedMacroParameter"/>
+   <rule ref="category/vm/design.xml/AvoidDeeplyNestedIfStmts"/>
+   <rule ref="category/vm/design.xml/CollapsibleIfStatements"/>
+   <rule ref="category/vm/design.xml/ExcessiveTemplateLength"/>
+   <rule ref="category/vm/design.xml/NoInlineJavaScript"/>
+   <rule ref="category/vm/design.xml/NoInlineStyles"/>
+   <rule ref="category/vm/errorprone.xml/EmptyForeachStmt"/>
+   <rule ref="category/vm/errorprone.xml/EmptyIfStmt"/>
+-->
 </ruleset>

--- a/module/jsonurl-core/src/main/java/org/jsonurl/Limits.java
+++ b/module/jsonurl-core/src/main/java/org/jsonurl/Limits.java
@@ -82,7 +82,7 @@ class Limits implements JsonUrlLimits { // NOPMD - DataClass
 
     @Override
     public int hashCode() {
-        final int prime = 31;
+        final int prime = 31; // NOPMD - AvoidFinalLocalVariable
         int result = 1;
         result = prime * result + (int) (maxParseChars ^ (maxParseChars >>> 32));
         result = prime * result + maxParseDepth;

--- a/module/jsonurl-core/src/main/java/org/jsonurl/ParseException.java
+++ b/module/jsonurl-core/src/main/java/org/jsonurl/ParseException.java
@@ -120,23 +120,23 @@ public class ParseException extends RuntimeException {
     @Override
     @SuppressWarnings("java:S1117") // See SuppressWarnings.md
     public String toString() {
-        StringBuilder buf = new StringBuilder(64);
+        final StringBuilder buf = new StringBuilder(64);
 
         buf.append("jsonurl ")
             .append(typeDescription())
             .append(": ")
             .append(getMessage());
 
-        int line = getLineNumber();
+        final int line = getLineNumber();
         if (line > -1) {
             buf.append(" at ").append(line);
             
-            int col = getColumn();
+            final int col = getColumn();
             if (col > -1) {
                 buf.append(':').append(col);
             }
         } else {
-            long off = getOffset();
+            final long off = getOffset();
             if (off > -1) {
                 buf.append(" at ").append(off);
             }            

--- a/module/jsonurl-core/src/main/java/org/jsonurl/text/JsonUrlTextAppender.java
+++ b/module/jsonurl-core/src/main/java/org/jsonurl/text/JsonUrlTextAppender.java
@@ -462,6 +462,7 @@ public abstract class JsonUrlTextAppender<A extends Appendable, R> // NOPMD
         // See SuppressWarnings.md#complexity
         "PMD.CyclomaticComplexity",
         "PMD.NPathComplexity",
+        "PMD.CognitiveComplexity",
         "java:S3776"
     })
     private static <T extends Appendable> boolean appendLiteral(

--- a/module/jsonurl-core/src/main/java/org/jsonurl/text/NumberCoercionMap.java
+++ b/module/jsonurl-core/src/main/java/org/jsonurl/text/NumberCoercionMap.java
@@ -55,11 +55,15 @@ import java.util.concurrent.atomic.LongAdder;
  *      <td>{@link java.lang.Double Double}</td></tr>
  * </table>
  */
-final class NumberCoercionMap { //NOPMD - ClassNamingConventions
+final class NumberCoercionMap {
 
     /**
      * Static map of input type to coerced type.
      */
+    // access is guaranteed to be sync inside the static initializer, and it
+    // is read-only thereafter. There's no need for the additional overhead
+    // of ConcurrentHashMap here.
+    @SuppressWarnings("PMD.UseConcurrentHashMap")
     private static final Map<
             Class<? extends Number>,
             Class<? extends Number>> MAP = new HashMap<>();

--- a/module/jsonurl-core/src/main/java/org/jsonurl/util/PercentCodec.java
+++ b/module/jsonurl-core/src/main/java/org/jsonurl/util/PercentCodec.java
@@ -70,6 +70,7 @@ public final class PercentCodec { // NOPMD - ClassNamingConventions
         // See SuppressWarnings.md#complexity
         "PMD.CyclomaticComplexity",
         "PMD.NPathComplexity",
+        "PMD.CognitiveComplexity",
         "java:S3776",
         
         // once you understand UTF-8 it's far more readable with the

--- a/module/jsonurl-core/src/test/java/org/jsonurl/stream/JsonUrlIteratorTest.java
+++ b/module/jsonurl-core/src/test/java/org/jsonurl/stream/JsonUrlIteratorTest.java
@@ -44,7 +44,10 @@ import org.junit.jupiter.params.provider.MethodSource;
  * @author David MacCormack
  * @since 2019-10-01
  */
-@SuppressWarnings("PMD.AvoidDuplicateLiterals")
+@SuppressWarnings({
+    "PMD.AvoidDuplicateLiterals",
+    "PMD.ExcessiveClassLength" // yup, I have a lot of tests
+})
 class JsonUrlIteratorTest {
 
     /** empty string. */
@@ -253,7 +256,10 @@ class JsonUrlIteratorTest {
         testEvents(test, jui);
     }
 
-    @SuppressWarnings("checkstyle:AbbreviationAsWordInName")
+    @SuppressWarnings({
+        "checkstyle:AbbreviationAsWordInName",
+        "PMD.ExcessiveMethodLength" // yup, I have a lot of tests
+    })
     static Stream<EventTest> testAQF() {
         return Stream.concat(COMMON_TESTS.parallelStream(),
             Arrays.stream(new EventTest[] {
@@ -428,7 +434,10 @@ class JsonUrlIteratorTest {
         testEvents(test, jui);
     }
 
-    @SuppressWarnings("checkstyle:AbbreviationAsWordInName")
+    @SuppressWarnings({
+        "checkstyle:AbbreviationAsWordInName",
+        "PMD.ExcessiveMethodLength" // yup, I have a lot of tests
+    })
     static Stream<EventTest> testNotAQF() {
         return Stream.concat(COMMON_TESTS.parallelStream(),
             Arrays.stream(new EventTest[] {

--- a/module/jsonurl-factory/src/main/java/org/jsonurl/j2se/JsonUrlWriter.java
+++ b/module/jsonurl-factory/src/main/java/org/jsonurl/j2se/JsonUrlWriter.java
@@ -76,6 +76,7 @@ public final class JsonUrlWriter { // NOPMD
     @SuppressWarnings({
         // See SuppressWarnings.md#complexity
         "PMD.CyclomaticComplexity",
+        "PMD.CognitiveComplexity",
         "PMD.NPathComplexity",
         "java:S3776"
     })
@@ -374,6 +375,7 @@ public final class JsonUrlWriter { // NOPMD
     @SuppressWarnings({
         // See SuppressWarnings.md
         "PMD.CyclomaticComplexity",
+        "PMD.CognitiveComplexity",
         "PMD.AvoidReassigningLoopVariables",
         "java:S127"
     })

--- a/module/jsonurl-factory/src/test/java/org/jsonurl/factory/AbstractJsonApiWriteTest.java
+++ b/module/jsonurl-factory/src/test/java/org/jsonurl/factory/AbstractJsonApiWriteTest.java
@@ -121,6 +121,6 @@ public abstract class AbstractJsonApiWriteTest<
         V obj2 = vfp.parse(jsonUriText);
 
         String jsonText = valueToString(obj2);
-        assertEquals(text, jsonText);
+        assertEquals(text, jsonText, text);
     }
 }

--- a/module/jsonurl-factory/src/test/java/org/jsonurl/factory/AbstractParseTest.java
+++ b/module/jsonurl-factory/src/test/java/org/jsonurl/factory/AbstractParseTest.java
@@ -73,6 +73,9 @@ import org.junit.jupiter.params.provider.ValueSource;
 @SuppressWarnings({
     "checkstyle:AbbreviationAsWordInName",
 
+    // yup, I have a lot of tests
+    "PMD.ExcessiveClassLength",
+
     //
     // though it is generally good to avoid duplicate literals,
     // inline literals in unit tests often makes them much easier to read
@@ -604,7 +607,8 @@ public abstract class AbstractParseTest<
 
             assertEquals(
                 factory.getString(EMPTY_STRING),
-                newParser(JsonUrlOption.EMPTY_UNQUOTED_VALUE).parse(text));
+                newParser(JsonUrlOption.EMPTY_UNQUOTED_VALUE).parse(text),
+                "empty string with option EMPTY_UNQUOTED_VALUE");
 
             assertEquals(
                 factory.getString(text),
@@ -897,7 +901,11 @@ public abstract class AbstractParseTest<
             }
         }
 
-        @SuppressWarnings("PMD.CyclomaticComplexity")
+        @SuppressWarnings({
+            // See SuppressWarnings.md
+            "PMD.CyclomaticComplexity",
+            "PMD.CognitiveComplexity"
+        })
         void testBigInteger(
                 String text,
                 MathContext mctx,
@@ -1370,7 +1378,9 @@ public abstract class AbstractParseTest<
                 makeImplied(text),
                 factory.newObjectBuilder());
             
-            assertTrue(isEqual(expectedObject, actualObject));
+            assertTrue(
+                isEqual(expectedObject, actualObject),
+                "empty implied object");
             
             A expectedArray = factory.newArray(factory.newArrayBuilder());
 
@@ -1378,7 +1388,9 @@ public abstract class AbstractParseTest<
                 makeImplied(text),
                 factory.newArrayBuilder());
             
-            assertTrue(isEqual(expectedArray, actualArray));
+            assertTrue(
+                isEqual(expectedArray, actualArray),
+                "empty implied array");
         }
 
         private void assertObjectWfu(String text, J actual) {

--- a/module/jsonurl-factory/src/test/java/org/jsonurl/j2se/JsonUrlWriterTest.java
+++ b/module/jsonurl-factory/src/test/java/org/jsonurl/j2se/JsonUrlWriterTest.java
@@ -325,6 +325,8 @@ class JsonUrlWriterTest {
     }
     
     private Map<?,?> newNonStringMap() {
+        // It's not used concurrently
+        @SuppressWarnings("PMD.UseConcurrentHashMap")
         Map<Object, Object> ret = new HashMap<>(); 
         ret.put(new Object(), new Object());
         return ret;

--- a/module/pom.xml
+++ b/module/pom.xml
@@ -49,7 +49,7 @@
     <maven.surefire.report.plugin>2.22.2</maven.surefire.report.plugin>
     <maven.javadoc.plugin>3.2.0</maven.javadoc.plugin>
     <maven.checkstyle.plugin>3.1.2</maven.checkstyle.plugin>
-    <maven.pmd.plugin>3.13.0</maven.pmd.plugin>
+    <maven.pmd.plugin>3.16.0</maven.pmd.plugin>
     <maven.jacoco.plugin>0.8.5</maven.jacoco.plugin>
     <maven.gpg.plugin>1.6</maven.gpg.plugin>
     <maven.site.plugin>3.8.2</maven.site.plugin>
@@ -88,7 +88,7 @@
 
     <checkstyle.config.file>config/checkstyle.xml</checkstyle.config.file>
     <checkstyle.config.module.location>../../${checkstyle.config.file}</checkstyle.config.module.location>
-    <pmd.version>6.28.0</pmd.version>
+    <pmd.version>6.43.0</pmd.version>
     <pmd.config.file>config/pmd-ruleset.xml</pmd.config.file>
     <pmd.config.module.location>../../${pmd.config.file}</pmd.config.module.location>
     <jacoco.minimum.coverage>0.80</jacoco.minimum.coverage>
@@ -173,6 +173,7 @@
           <version>${maven.jar.plugin}</version>
         </plugin>
         <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-javadoc-plugin</artifactId>
           <version>${maven.javadoc.plugin}</version>
           <configuration>
@@ -198,6 +199,7 @@
           <version>${maven.surefire.plugin}</version>
         </plugin>
         <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-checkstyle-plugin</artifactId>
           <version>${maven.checkstyle.plugin}</version>
           <configuration>
@@ -217,6 +219,7 @@
           </dependencies>
         </plugin>
         <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-pmd-plugin</artifactId>
           <version>${maven.pmd.plugin}</version>
           <dependencies>
@@ -503,6 +506,7 @@
           </plugin>
 
           <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-surefire-report-plugin</artifactId>
             <configuration>
               <linkXRef>false</linkXRef>
@@ -521,6 +525,7 @@
           </plugin>
 
           <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-changelog-plugin</artifactId>
             <configuration>
               <displayChangeSetDetailUrl>${jsonurl.scm.url}/commit/%REV%</displayChangeSetDetailUrl>
@@ -530,6 +535,7 @@
           </plugin>
 
           <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-checkstyle-plugin</artifactId>
             <reportSets>
               <reportSet>
@@ -547,6 +553,7 @@
           </plugin>
 
           <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-pmd-plugin</artifactId>
             <reportSets>
               <reportSet>


### PR DESCRIPTION
This patch bumps the Maven PMD plugin from 3.13.0 -> 3.16.0 as well
as the version of PMD used by the Maven PMD plugin, from
6.28.0 -> 6.43.0. This matches the version of PMD used by the
latest stable pmd-eclipse-plugin (4.32.0).

This patch removes deprecated rules from the PMD ruleset, and updates
the source where necessary to account for new rules.