### PR TITLE
fix: Fix bug stringifying number-like keys and values

### DIFF
--- a/module/jsonurl-core/src/main/java/org/jsonurl/text/JsonUrlTextAppender.java
+++ b/module/jsonurl-core/src/main/java/org/jsonurl/text/JsonUrlTextAppender.java
@@ -520,6 +520,23 @@ public abstract class JsonUrlTextAppender<A extends Appendable, R> // NOPMD
             }
             return true;
         }
+        
+        if (NumberBuilder.isNumber(text, start, end, false, true, options)) {
+            //
+            // Special handling if this would look like a number literal once
+            // the space is replaced with '+' 
+            //
+            if (optionAQF(options)) {
+                dest.append('!');
+                encodeAqf(dest, text, start, end);
+
+            } else {
+                dest.append('\'');
+                encode(dest, text, start, end, true, false);
+                dest.append('\'');
+            }
+            return true;
+        }
 
         if (optionAQF(options)) {
             encodeAqf(dest, text, start, end);

--- a/module/jsonurl-core/src/main/java/org/jsonurl/text/JsonUrlTextAppender.java
+++ b/module/jsonurl-core/src/main/java/org/jsonurl/text/JsonUrlTextAppender.java
@@ -463,6 +463,7 @@ public abstract class JsonUrlTextAppender<A extends Appendable, R> // NOPMD
         "PMD.CyclomaticComplexity",
         "PMD.NPathComplexity",
         "PMD.CognitiveComplexity",
+        "PMD.ExcessiveMethodLength",
         "java:S3776"
     })
     private static <T extends Appendable> boolean appendLiteral(

--- a/module/jsonurl-core/src/test/java/org/jsonurl/stream/JsonUrlIteratorTest.java
+++ b/module/jsonurl-core/src/test/java/org/jsonurl/stream/JsonUrlIteratorTest.java
@@ -414,6 +414,17 @@ class JsonUrlIteratorTest {
                         "(hello)",
                         JsonUrlEvent.END_STREAM}),
 
+                new EventTest(
+                    "(!1e+1:!1e+1)",
+                    new Object[] {
+                        JsonUrlEvent.START_OBJECT,
+                        JsonUrlEvent.KEY_NAME,
+                        "1e 1",
+                        JsonUrlEvent.VALUE_STRING,
+                        "1e 1",
+                        JsonUrlEvent.END_OBJECT,
+                        JsonUrlEvent.END_STREAM}),
+
             }));
     }
 
@@ -605,6 +616,17 @@ class JsonUrlIteratorTest {
                     new Object[] {
                         JsonUrlEvent.VALUE_STRING,
                         "!(hello!)",
+                        JsonUrlEvent.END_STREAM}),
+
+                new EventTest(
+                    "('1e+1':'1e+1')",
+                    new Object[] {
+                        JsonUrlEvent.START_OBJECT,
+                        JsonUrlEvent.KEY_NAME,
+                        "1e 1",
+                        JsonUrlEvent.VALUE_STRING,
+                        "1e 1",
+                        JsonUrlEvent.END_OBJECT,
                         JsonUrlEvent.END_STREAM}),
 
             }));
@@ -1246,6 +1268,17 @@ class JsonUrlIteratorTest {
                     JsonUrlEvent.KEY_NAME,
                     "a",
                     JsonUrlEvent.START_OBJECT,
+                    JsonUrlEvent.END_OBJECT,
+                    JsonUrlEvent.END_STREAM}),
+
+            new EventTest(
+                "(1e+1:1e+1)",
+                new Object[] {
+                    JsonUrlEvent.START_OBJECT,
+                    JsonUrlEvent.KEY_NAME,
+                    "1e+1",
+                    JsonUrlEvent.VALUE_NUMBER,
+                    "1e+1",
                     JsonUrlEvent.END_OBJECT,
                     JsonUrlEvent.END_STREAM}),
 

--- a/module/jsonurl-core/src/test/java/org/jsonurl/text/JsonUrlStringBuilderTest.java
+++ b/module/jsonurl-core/src/test/java/org/jsonurl/text/JsonUrlStringBuilderTest.java
@@ -527,6 +527,33 @@ class JsonUrlStringBuilderTest {
              expected);
     }
 
+    @Test
+    void testText7() throws IOException {
+        String expectedAqf = "(!1e+3:1)";
+        assertEquals(
+            expectedAqf,
+            new JsonUrlStringBuilder(JsonUrlOption.AQF)
+            .beginObject()
+            .addKey("1e 3")
+            .nameSeparator()
+            .add(1)
+            .endObject()
+            .build(),
+            expectedAqf);
+
+        String expected = "('1e+3':1)";
+        assertEquals(
+            expected,
+            new JsonUrlStringBuilder()
+            .beginObject()
+            .addKey("1e 3")
+            .nameSeparator()
+            .add(1)
+            .endObject()
+            .build(),
+            expected);
+    }
+
     @ParameterizedTest
     @Tag("exception")
     @ValueSource(strings = {

--- a/module/jsonurl-factory/src/test/java/org/jsonurl/factory/AbstractParseTest.java
+++ b/module/jsonurl-factory/src/test/java/org/jsonurl/factory/AbstractParseTest.java
@@ -618,13 +618,13 @@ public abstract class AbstractParseTest<
                     .parse(text),
                 text);
         }
-        
+
         @ParameterizedTest
         @NullSource
         @EnumSource(names = "AQF")
-        @DisplayName("testLiteral1: 1e+1")
-        void testLiteral1(JsonUrlOption option) throws IOException {
-            final String desc = "1e%2B1";
+        @DisplayName("testNumberLikeLiteral: 1e+1")
+        void testNumberLikeLiteral(JsonUrlOption option) throws IOException {
+            final String desc = "1e+1";
 
             // parse("1e+1") -> number(10)
             assertEquals(
@@ -634,7 +634,7 @@ public abstract class AbstractParseTest<
             
             // stringify("1e 1") -> string("1e+1")
             assertEquals(
-                "1e+1",
+                option == null ? "'1e+1'" : "!1e+1",
                 new JsonUrlStringBuilder(
                     newOptions(option)).add("1e 1").build(),
                 desc);
@@ -652,8 +652,8 @@ public abstract class AbstractParseTest<
         @ParameterizedTest
         @NullSource
         @EnumSource(names = "AQF")
-        @DisplayName("testLiteral2: 1e%2B1")
-        void testLiteral2(JsonUrlOption option) throws IOException {
+        @DisplayName("testNumberLikeStringLiteral: 1e%2B1")
+        void testNumberLikeStringLiteral(JsonUrlOption option) throws IOException {
             final String desc = "1e%2B1";
 
             if (option == JsonUrlOption.AQF) {


### PR DESCRIPTION
A string like "1e 6" will currently be stringified as 1e+6, which is
ambiguous because it looks like a number literal and it will be parsed
as one. This patch fixes the stringify code so that these strings are
quoted. AQF strings have a similar issue and this patch addresses them
as well.