### PR TITLE
chore: Update PMD to match Eclipse plug-in 4.44.0.v20230225-1718-r

### DIFF
--- a/module/jsonurl-core/src/main/java/org/jsonurl/text/NumberBuilder.java
+++ b/module/jsonurl-core/src/main/java/org/jsonurl/text/NumberBuilder.java
@@ -295,7 +295,7 @@ public class NumberBuilder implements NumberText { // NOPMD
             BigMathProvider mcp,
             Set<JsonUrlOption> options) {
         this.mcp = mcp;
-        parse(text, start, stop, options);
+        parse(text, start, stop, options); // NOPMD - ConstructorCallsOverridableMethod
     }
 
     /**

--- a/module/jsonurl-core/src/test/java/org/jsonurl/stream/JsonUrlIteratorTest.java
+++ b/module/jsonurl-core/src/test/java/org/jsonurl/stream/JsonUrlIteratorTest.java
@@ -46,7 +46,8 @@ import org.junit.jupiter.params.provider.MethodSource;
  */
 @SuppressWarnings({
     "PMD.AvoidDuplicateLiterals",
-    "PMD.ExcessiveClassLength" // yup, I have a lot of tests
+    "PMD.ExcessiveClassLength", // yup, I have a lot of tests
+    "PMD.TestClassWithoutTestCases"
 })
 class JsonUrlIteratorTest {
 
@@ -235,7 +236,10 @@ class JsonUrlIteratorTest {
     
     @ParameterizedTest
     @MethodSource
-    @SuppressWarnings("checkstyle:AbbreviationAsWordInName")
+    @SuppressWarnings({
+        "checkstyle:AbbreviationAsWordInName",
+        "PMD.JUnitTestsShouldIncludeAssert"
+    })
     void testAQF(EventTest test) throws IOException {
         CharIterator text = new JsonUrlCharSequence(
             "testAQF",
@@ -419,7 +423,10 @@ class JsonUrlIteratorTest {
 
     @ParameterizedTest
     @MethodSource
-    @SuppressWarnings("checkstyle:AbbreviationAsWordInName")
+    @SuppressWarnings({
+        "checkstyle:AbbreviationAsWordInName",
+        "PMD.JUnitTestsShouldIncludeAssert"
+    })
     void testNotAQF(EventTest test) throws IOException {
         CharIterator text = new JsonUrlCharSequence(
             "testNotAqf",

--- a/module/jsonurl-core/src/test/java/org/jsonurl/text/JsonUrlStringBuilderTest.java
+++ b/module/jsonurl-core/src/test/java/org/jsonurl/text/JsonUrlStringBuilderTest.java
@@ -575,6 +575,7 @@ class JsonUrlStringBuilderTest {
         "f", "fa", "fal", "fals", "False", "fAlse", "faLse", "falSe", "falsE",
         "n", "nu", "nul", "Null", "nUll", "nuLl", "nulL",
     })
+    @SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
     void testNonQuotedString(String text) throws IOException {
         testValue(text, text, text, text, text, text);
     }
@@ -583,6 +584,7 @@ class JsonUrlStringBuilderTest {
     @ValueSource(strings = {
         "true", "false", "null", "1", "1.0", "1e3", "1e-3",
     })
+    @SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
     void testQuotedString(String text) throws IOException {
         testValue(text, text, '\'' + text + '\'', text, '!' + text, text);
     }
@@ -607,6 +609,7 @@ class JsonUrlStringBuilderTest {
         //
         "1e+3,1e%2B3,1e%2B3,1e!+3,1e!+3",
     })
+    @SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
     void testEncodedString(
             String text,
             String expected,

--- a/module/jsonurl-core/src/test/java/org/jsonurl/text/NumberBuilderTest.java
+++ b/module/jsonurl-core/src/test/java/org/jsonurl/text/NumberBuilderTest.java
@@ -418,6 +418,7 @@ class NumberBuilderTest { // NOPMD
     @ValueSource(strings = {
         Long.MAX_VALUE + "0",
     })
+    @SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
     void testOverflow(String text) {
         testOverflow(
             text,

--- a/module/jsonurl-factory/src/test/java/org/jsonurl/factory/AbstractParseTest.java
+++ b/module/jsonurl-factory/src/test/java/org/jsonurl/factory/AbstractParseTest.java
@@ -1005,6 +1005,7 @@ public abstract class AbstractParseTest<
             BIG_INTEGER128_BOUNDARY_POS + '0',
             '-' + BIG_INTEGER128_BOUNDARY_NEG + '0',
         })
+        @SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
         void testBigInteger(String text) throws IOException {
             if (!(factory instanceof BigMathProvider)) {
                 return;

--- a/module/jsonurl-jsonorg/src/test/java/org/jsonurl/jsonorg/JsonOrgApiWriteTest.java
+++ b/module/jsonurl-jsonorg/src/test/java/org/jsonurl/jsonorg/JsonOrgApiWriteTest.java
@@ -31,6 +31,7 @@ import org.jsonurl.text.JsonTextBuilder;
  * @author David MacCormack
  * @since 2019-09-01
  */
+@SuppressWarnings("PMD.TestClassWithoutTestCases")
 public class JsonOrgApiWriteTest extends AbstractJsonApiWriteTest<
         Object,
         Object,

--- a/module/pom.xml
+++ b/module/pom.xml
@@ -88,7 +88,7 @@
 
     <checkstyle.config.file>config/checkstyle.xml</checkstyle.config.file>
     <checkstyle.config.module.location>../../${checkstyle.config.file}</checkstyle.config.module.location>
-    <pmd.version>6.43.0</pmd.version>
+    <pmd.version>6.55.0</pmd.version>
     <pmd.config.file>config/pmd-ruleset.xml</pmd.config.file>
     <pmd.config.module.location>../../${pmd.config.file}</pmd.config.module.location>
     <jacoco.minimum.coverage>0.80</jacoco.minimum.coverage>


### PR DESCRIPTION
Updates the POM and addresses errors from new rules.